### PR TITLE
Run-time derived type for enabling UVM sharing of classes with virtual methods

### DIFF
--- a/jitify.hpp
+++ b/jitify.hpp
@@ -676,6 +676,25 @@ struct type_reflection<NonType<T,VALUE> > {
 
 //! \endcond
 
+/*! Create an Instance object that contains a const reference to the
+ *  value.  We use this to wrap abstract objects from which we want to extract
+ *  their type at runtime (e.g., derived type).  This is used to facilitate
+ *  templating on derived type when all we know at compile time is abstract type.
+*/
+template<typename T>
+struct Instance {
+const T &value;
+	Instance( const T &value ) : value(value) {}
+};
+
+/*! Create an Instance object from which we can extract the value's run-time type.
+ *  \param value The const value to be captured.
+ */
+template<typename T>
+inline Instance<T const> instance_of(T const& value) {
+	return Instance<T const>(value);
+}
+
 /*! A wrapper used for representing types as values.
  */
 template<typename T>
@@ -721,6 +740,17 @@ template<typename T, T N> inline std::string reflect() {
  */
 template<typename T> inline std::string reflect(jitify::reflection::Type<T> ) {
 	return reflect<T>();
+}
+
+/*! Generate a code-string for a type wrapped as an Instance instance.
+ *  \code{.cpp}reflect(Instance<float>(3.1f)) --> "float"\endcode
+ *  or more simply when passed to a instance_of helper
+ *  \code{.cpp}reflect(instance_of(3.1f)) --> "float"\endcodei
+ *  This is specifically for the case where we want to extract the run-time type,
+ *  e.g., derived type, of an object pointer.
+ */
+template<typename T> inline std::string reflect(jitify::reflection::Instance<T> &value) {
+	return detail::demangle(typeid(value.value).name());
 }
 
 // Type from value

--- a/jitify_example.cpp
+++ b/jitify_example.cpp
@@ -134,6 +134,7 @@ bool test_kernels() {
 	using jitify::reflection::NonType;
 	using jitify::reflection::Type;
 	using jitify::reflection::type_of;
+	using jitify::reflection::instance_of;
 	
 	thread_local static jitify::JitCache kernel_cache;
 	jitify::Program program = kernel_cache.program
@@ -177,6 +178,11 @@ bool test_kernels() {
 	CHECK_CUDA( program
 	            .kernel("my_kernel2")
 	            .instantiate((int)C, type_of(*indata))
+	            .configure(grid,block)
+	            .launch(indata, outdata) );
+	CHECK_CUDA( program
+	            .kernel("my_kernel2")
+	            .instantiate((int)C, instance_of(*indata))
 	            .configure(grid,block)
 	            .launch(indata, outdata) );
 	


### PR DESCRIPTION
Added support for extracting run-time type with the `instance_of` helper which wraps around the `Instance` struct: this allows us to template on run-time derived type when all we know at (host) compile time is the base pointer type.  

In the context of UVM, this facilitates the sharing of host-allocated classes with the device which have virtual functions, e.g., is a way to move beyond only being able to share POD object pointers with the device.  For example, we can pass a UVM-allocated abstract base pointer to the GPU, but template on the derived type, which is only known at runtime.  Then in the kernel we want to access the class members, we statically cast the base pointer to the template type (derived pointer), dereference the pointer and now pass this by value to a function.  Now the object (copy) is safe to access, including its virtual functions.

See the example below, where we first show the listing for "simple_jit.h"
```c++
class Managed {
 public:

 void *operator new(size_t len) {
   void *ptr = nullptr;
#ifndef __CUDA_ARCH__
   cudaMallocManaged(&ptr, len);
   cudaDeviceSynchronize();
#endif
   return ptr;
 }

 void operator delete(void *ptr) {
#ifndef __CUDA_ARCH__
   cudaDeviceSynchronize();
   cudaFree(ptr);
#endif
 }
};

class MyTestClass : public Managed {
public:

public:
  MyTestClass() {}
  __host__ __device__ virtual bool checkIt() = 0;
  virtual ~MyTestClass() { }
};

class MySubTestClass : public MyTestClass {
public:
  MySubTestClass() { }
  __host__ __device__ bool checkIt () { return true; }
  virtual ~MySubTestClass() { }
};

// this works but requires we know the derived type at CPU compilation time to pass by value                                                                                                                                                                                                                                                                              
__global__ void valueTest(MySubTestClass obj) { obj.checkIt(); }

// this fails since the GPU tries to access the CPU's vtable                                                                                                                                                                                                                                                                                                              
__global__ void pointerTest(MyTestClass *obj) { obj->checkIt(); }

template<typename T>
__host__ __device__ void test(T obj) { obj.checkIt(); }

// this works                                                                                                                                                                                                                                                                                                                                                             
template<typename T>
__global__ void jitPointerTest(MyTestClass *obj) { test<T>( *(static_cast<T*>(obj)) ); }
```

and here is the main program
```c++
#include<jitify.hpp>
#include<simple_jit.h>

void checkCudaError (int line) {
  auto err = cudaDeviceSynchronize();
  if (err != cudaSuccess) printf ("You got the error: %s (at line %d)\n", cudaGetErrorString(err), line);
  else printf("Success\n");
}

#define CHECK_CUDA(call) do { if( call != CUDA_SUCCESS ) { return false; } } while(0)

int main() {

  int deviceId;
  cudaGetDevice(&deviceId);

  // only have pointer to base class
  MyTestClass *myClass = new MySubTestClass();

  using namespace jitify;
  using namespace jitify::reflection;
  static JitCache kernel_cache;
  static Program program = kernel_cache.program("simple_jit.h", 0, {"-std=c++11"});

  printf ("Passing by value....");
  CHECK_CUDA(program.kernel("valueTest").instantiate().configure(1,1).launch(*static_cast<MySubTestClass*>(myClass)));
  checkCudaError(__LINE__);

  printf ("\nJIT passing by pointer....");
  CHECK_CUDA(program.kernel("jitPointerTest").instantiate( instance_of(*myClass) ).configure(1,1).launch(myClass));
  checkCudaError(__LINE__);

  printf ("\nPassing by pointer....");
  CHECK_CUDA(program.kernel("pointerTest").instantiate().configure(1,1).launch(myClass));
  checkCudaError(__LINE__);

  delete myClass;
}
```
The resulting output is as expected: passing by value trivially works, so-called JIT passing by pointer works, and the regular pass by pointer fails.
```
./simple_jit 
Passing by value....Success

JIT passing by pointer....Success

Passing by pointer....You got the error: an illegal memory access was encountered (at line 34)
```