### PR TITLE
Feature/type traits

### DIFF
--- a/jitify.hpp
+++ b/jitify.hpp
@@ -1180,20 +1180,74 @@ static const char* jitsafe_header_type_traits = R"(
     #pragma once
     #if __cplusplus >= 201103L
     namespace __jitify_type_traits_ns {
+
     template<bool B, class T = void> struct enable_if {};
     template<class T>                struct enable_if<true, T> { typedef T type; };
+    #if __cplusplus >= 201402L
+    template< bool B, class T = void > using enable_if_t = typename enable_if<B,T>::type
+    #endif
 
-    struct true_type  { enum { value = true }; };
-    struct false_type { enum { value = false }; };
+    struct true_type  {
+      enum { value = true };
+      operator bool() const { return true; }
+    };
+    struct false_type {
+      enum { value = false };
+      operator bool() const { return false; }
+    };
+
     template<typename T> struct is_floating_point    : false_type {};
     template<> struct is_floating_point<float>       :  true_type {};
     template<> struct is_floating_point<double>      :  true_type {};
     template<> struct is_floating_point<long double> :  true_type {};
 
+    template<class T> struct is_integral              : false_type {};
+    template<> struct is_integral<bool>               :  true_type {};
+    template<> struct is_integral<char>               :  true_type {};
+    template<> struct is_integral<signed char>        :  true_type {};
+    template<> struct is_integral<unsigned char>      :  true_type {};
+    template<> struct is_integral<short>              :  true_type {};
+    template<> struct is_integral<unsigned short>     :  true_type {};
+    template<> struct is_integral<int>                :  true_type {};
+    template<> struct is_integral<unsigned int>       :  true_type {};
+    template<> struct is_integral<long>               :  true_type {};
+    template<> struct is_integral<unsigned long>      :  true_type {};
+    template<> struct is_integral<long long>          :  true_type {};
+    template<> struct is_integral<unsigned long long> :  true_type {};
+
+    template<typename T> struct is_signed    : false_type {};
+    template<> struct is_signed<float>       :  true_type {};
+    template<> struct is_signed<double>      :  true_type {};
+    template<> struct is_signed<long double> :  true_type {};
+    template<> struct is_signed<signed char> :  true_type {};
+    template<> struct is_signed<short>       :  true_type {};
+    template<> struct is_signed<int>         :  true_type {};
+    template<> struct is_signed<long>        :  true_type {};
+    template<> struct is_signed<long long>   :  true_type {};
+
+    template<typename T> struct is_unsigned             : false_type {};
+    template<> struct is_unsigned<unsigned char>      :  true_type {};
+    template<> struct is_unsigned<unsigned short>     :  true_type {};
+    template<> struct is_unsigned<unsigned int>       :  true_type {};
+    template<> struct is_unsigned<unsigned long>      :  true_type {};
+    template<> struct is_unsigned<unsigned long long> :  true_type {};
+
     template<typename T, typename U> struct is_same      : false_type {};
     template<typename T>             struct is_same<T,T> :  true_type {};
-    template<class>
-    struct result_of;
+
+    template<class T> struct is_array : false_type {};
+    template<class T> struct is_array<T[]> : true_type {};
+    template<class T, size_t N> struct is_array<T[N]> : true_type {};
+
+    //partial implementation only of is_function
+    template<class> struct is_function : false_type { };
+    template<class Ret, class... Args> struct is_function<Ret(Args...)> : true_type {}; //regular
+    template<class Ret, class... Args> struct is_function<Ret(Args......)> : true_type {}; // variadic
+    #if __cplusplus >= 201402L
+    template< class T > inline constexpr bool is_function_v = is_function<T>::value;
+    #endif
+
+    template<class> struct result_of;
     template<class F, typename... Args>
     struct result_of<F(Args...)> {
     // TODO: This is a hack; a proper implem is quite complicated.
@@ -1203,6 +1257,56 @@ static const char* jitsafe_header_type_traits = R"(
     template <class T> struct remove_reference { typedef T type; };
     template <class T> struct remove_reference<T&> { typedef T type; };
     template <class T> struct remove_reference<T&&> { typedef T type; };
+    #if __cplusplus >= 201402L
+    template< class T > using remove_reference_t = typename remove_reference<T>::type;
+    #endif
+
+    template<class T> struct remove_extent { typedef T type; };
+    template<class T> struct remove_extent<T[]> { typedef T type; };
+    template<class T, size_t N> struct remove_extent<T[N]> { typedef T type; };
+    #if __cplusplus >= 201402L
+    template< class T > using remove_extent_t = typename remove_extent<T>::type;
+    #endif
+
+    template< class T > struct remove_const          { typedef T type; };
+    template< class T > struct remove_const<const T> { typedef T type; };
+    template< class T > struct remove_volatile             { typedef T type; };
+    template< class T > struct remove_volatile<volatile T> { typedef T type; };
+    template< class T > struct remove_cv { typedef typename remove_volatile<typename remove_const<T>::type>::type type; };
+    #if __cplusplus >= 201402L
+    template< class T > using remove_cv_t       = typename remove_cv<T>::type;
+    template< class T > using remove_const_t    = typename remove_const<T>::type;
+    template< class T > using remove_volatile_t = typename remove_volatile<T>::type;
+    #endif
+
+    template<bool B, class T, class F> struct conditional { typedef T type; };
+    template<class T, class F> struct conditional<false, T, F> { typedef F type; };
+    #if __cplusplus >= 201402L
+    template< bool B, class T, class F > using conditional_t = typename conditional<B,T,F>::type;
+    #endif
+
+    namespace __jitify_detail {
+    template< class T, bool is_function_type = false > struct add_pointer { using type = typename remove_reference<T>::type*; };
+    template< class T > struct add_pointer<T, true> { using type = T; };
+    template< class T, class... Args > struct add_pointer<T(Args...), true> { using type = T(*)(Args...); };
+    template< class T, class... Args > struct add_pointer<T(Args..., ...), true> { using type = T(*)(Args..., ...); };
+    }
+    template< class T > struct add_pointer : __jitify_detail::add_pointer<T, is_function<T>::value> {};
+    #if __cplusplus >= 201402L
+    template< class T > using add_pointer_t = typename add_pointer<T>::type
+    #endif
+
+    template< class T > struct decay {
+    private:
+      typedef typename remove_reference<T>::type U;
+    public:
+      typedef typename conditional<is_array<U>::value, typename remove_extent<U>::type*,
+        typename conditional<is_function<U>::value,typename add_pointer<U>::type,typename remove_cv<U>::type
+        >::type>::type type;
+    };
+    #if __cplusplus >= 201402L
+    template< class T > using decay_t = typename decay<T>::type;
+    #endif
 
     } // namespace __jtiify_type_traits_ns
     namespace std { using namespace __jitify_type_traits_ns; }

--- a/jitify.hpp
+++ b/jitify.hpp
@@ -883,7 +883,7 @@ class CUDAKernel {
   std::string _ptx;
   std::vector<CUjit_option> _opts;
 
-  inline void cuda_safe_call(CUresult res) {
+  inline void cuda_safe_call(CUresult res) const {
     if (res != CUDA_SUCCESS) {
       const char* msg;
       cuGetErrorName(res, &msg);
@@ -2237,8 +2237,10 @@ class Program {
   JITIFY_DEFINE_AUTO_PTR_COPY_WAR(Program)
   /*! Select a kernel.
    *
-   * \param name The name of the kernel (unmangled and without template arguments).
-   * \param options A vector of options to be passed to the NVRTC compiler when compiling this kernel.
+   * \param name The name of the kernel (unmangled and without
+   * template arguments).
+   * \param options A vector of options to be passed to the NVRTC
+   * compiler when compiling this kernel.
    */
   inline Kernel kernel(std::string name,
                        jitify::detail::vector<std::string> options = 0) const {
@@ -2546,6 +2548,12 @@ inline void Program_impl::load_sources(std::string source,
   std::vector<std::string> linker_paths;
   detail::split_compiler_and_linker_options(options, &compiler_options,
                                             &linker_files, &linker_paths);
+
+  // If no arch is specified at this point we use whatever the current
+  // context is.  This ensures we pick up the correct internal headers
+  // for arch-dependent compilation, e.g., some intrinsics are only
+  // present for specific architectures
+  detail::detect_and_add_cuda_arch(compiler_options);
 
   std::string log;
   nvrtcResult ret;

--- a/jitify.hpp
+++ b/jitify.hpp
@@ -680,9 +680,18 @@ inline std::string demangle(const char* mangled_name) {
 inline std::string demangle(const char* mangled_name) {
   size_t bufsize = 1024;
   char* buf = (char*)malloc(bufsize);
+  std::string demangled_name;
   int status;
-  std::string demangled_name =
-      abi::__cxa_demangle(mangled_name, buf, &bufsize, &status);
+  char *demangled_ptr = abi::__cxa_demangle(mangled_name, buf, &bufsize, &status);
+  if (status == 0) {
+    demangled_name = demangled_ptr; // all worked as expected
+  } else if (status == -2) {
+    demangled_name = mangled_name;  // we interpret this as plain C name
+  } else if (status == -1) {
+    throw std::runtime_error(std::string("memory allocation failure in __cxa_demangle"));
+  } else if (status == -3) {
+    throw std::runtime_error(std::string("invalid argument to __cxa_demangle"));
+  }
   free(buf);
   return demangled_name;
 }

--- a/jitify.hpp
+++ b/jitify.hpp
@@ -572,7 +572,7 @@ inline bool load_source(
   // HACK TESTING (WAR for cub)
   // source = "#define cudaDeviceSynchronize() cudaSuccess\n" + source;
   ////source = "cudaError_t cudaDeviceSynchronize() { return cudaSuccess; }\n" +
-  ///source;
+  /// source;
 
   // WAR for #pragma once causing problems when there are multiple inclusions
   //   of the same header from different paths.
@@ -698,13 +698,13 @@ struct type_reflection {
     const char* mangled_name = typeid(T*).name() + 1;
     return demangle(mangled_name);
     //#else
-    //		std::string ret;
-    //		nvrtcResult status = nvrtcGetTypeName<T>(&ret);
-    //		if( status != NVRTC_SUCCESS ) {
-    //			throw std::runtime_error(std::string("nvrtcGetTypeName failed:
-    //")+ 			                         nvrtcGetErrorString(status));
-    //		}
-    //		return ret;
+    // std::string ret;
+    // nvrtcResult status = nvrtcGetTypeName<T>(&ret);
+    // if ( status != NVRTC_SUCCESS ) {
+    //  throw std::runtime_error(std::string("nvrtcGetTypeName failed:") +
+    //                           nvrtcGetErrorString(status));
+    //}
+    // return ret;
     //#endif
   }
 };
@@ -1387,7 +1387,7 @@ static const char* jitsafe_header_string =
     "struct basic_string {\n"
     "basic_string();\n"
     "basic_string( const CharT* s );\n"  //, const Allocator& alloc =
-                                         //Allocator() );\n"
+                                         // Allocator() );\n"
     "const CharT* c_str() const;\n"
     "bool empty() const;\n"
     "void operator+=(const char *);\n"
@@ -1532,6 +1532,23 @@ static const char* jitsafe_header_math =
     // Note: Global namespace already includes CUDA math funcs
     "//using namespace __jitify_math_ns;\n";
 
+// TODO: incomplete
+static const char* jitsafe_header_mutex = R"(
+     #pragma once
+     #if __cplusplus >= 201103L
+     namespace __jitify_mutex_ns {
+     class mutex {
+     public:
+     void lock();
+     bool try_lock();
+     void unlock();
+     };
+     // namespace __jitify_mutex_ns
+     namespace std { using namespace __jitify_mutex_ns; }
+     using namespace __jitify_mutex_ns;
+     #endif
+ )";
+
 static const char* jitsafe_headers[] = {
     jitsafe_header_preinclude_h, jitsafe_header_float_h,
     jitsafe_header_float_h,      jitsafe_header_limits_h,
@@ -1547,7 +1564,7 @@ static const char* jitsafe_headers[] = {
     jitsafe_header_iostream,     jitsafe_header_ostream,
     jitsafe_header_istream,      jitsafe_header_sstream,
     jitsafe_header_vector,       jitsafe_header_string,
-    jitsafe_header_stdexcept};
+    jitsafe_header_stdexcept,    jitsafe_header_mutex};
 static const char* jitsafe_header_names[] = {"jitify_preinclude.h",
                                              "float.h",
                                              "cfloat",
@@ -1576,7 +1593,8 @@ static const char* jitsafe_header_names[] = {"jitify_preinclude.h",
                                              "sstream",
                                              "vector",
                                              "string",
-                                             "stdexcept"};
+                                             "stdexcept",
+                                             "mutex"};
 
 template <class T, size_t N>
 size_t array_size(T (&)[N]) {

--- a/jitify.hpp
+++ b/jitify.hpp
@@ -1176,34 +1176,39 @@ static const char* jitsafe_header_limits =
     "using namespace __jitify_limits_ns;\n";
 
 // TODO: This is highly incomplete
-static const char* jitsafe_header_type_traits =
-    "#pragma once\n"
-    "#if __cplusplus >= 201103L\n"
-    "namespace __jitify_type_traits_ns {\n"
-    "template<bool B, class T = void> struct enable_if {};\n"
-    "template<class T>                struct enable_if<true, T> { typedef T "
-    "type; };\n"
-    "\n"
-    "struct true_type  { enum { value = true }; };\n"
-    "struct false_type { enum { value = false }; };\n"
-    "template<typename T> struct is_floating_point    : false_type {};\n"
-    "template<> struct is_floating_point<float>       :  true_type {};\n"
-    "template<> struct is_floating_point<double>      :  true_type {};\n"
-    "template<> struct is_floating_point<long double> :  true_type {};\n"
-    "\n"
-    "template<typename T, typename U> struct is_same      : false_type {};\n"
-    "template<typename T>             struct is_same<T,T> :  true_type {};\n"
-    "template<class>\n"
-    "struct result_of;\n"
-    "template<class F, typename... Args>\n"
-    "struct result_of<F(Args...)> {\n"
+static const char* jitsafe_header_type_traits = R"(
+    #pragma once
+    #if __cplusplus >= 201103L
+    namespace __jitify_type_traits_ns {
+    template<bool B, class T = void> struct enable_if {};
+    template<class T>                struct enable_if<true, T> { typedef T type; };
+
+    struct true_type  { enum { value = true }; };
+    struct false_type { enum { value = false }; };
+    template<typename T> struct is_floating_point    : false_type {};
+    template<> struct is_floating_point<float>       :  true_type {};
+    template<> struct is_floating_point<double>      :  true_type {};
+    template<> struct is_floating_point<long double> :  true_type {};
+
+    template<typename T, typename U> struct is_same      : false_type {};
+    template<typename T>             struct is_same<T,T> :  true_type {};
+    template<class>
+    struct result_of;
+    template<class F, typename... Args>
+    struct result_of<F(Args...)> {
     // TODO: This is a hack; a proper implem is quite complicated.
-    "	typedef typename F::result_type type;\n"
-    "};\n"
-    "} // namespace __jtiify_type_traits_ns\n"
-    "namespace std { using namespace __jitify_type_traits_ns; }\n"
-    "using namespace __jitify_type_traits_ns;\n"
-    "#endif // c++11\n";
+    typedef typename F::result_type type;
+    };
+
+    template <class T> struct remove_reference { typedef T type; };
+    template <class T> struct remove_reference<T&> { typedef T type; };
+    template <class T> struct remove_reference<T&&> { typedef T type; };
+
+    } // namespace __jtiify_type_traits_ns
+    namespace std { using namespace __jitify_type_traits_ns; }
+    using namespace __jitify_type_traits_ns;
+    #endif // c++11
+)";
 
 // TODO: INT_FAST8_MAX et al. and a few other misc constants
 static const char* jitsafe_header_stdint_h =
@@ -1534,19 +1539,19 @@ static const char* jitsafe_header_math =
 
 // TODO: incomplete
 static const char* jitsafe_header_mutex = R"(
-     #pragma once
-     #if __cplusplus >= 201103L
-     namespace __jitify_mutex_ns {
-     class mutex {
-     public:
-     void lock();
-     bool try_lock();
-     void unlock();
-     };
-     // namespace __jitify_mutex_ns
-     namespace std { using namespace __jitify_mutex_ns; }
-     using namespace __jitify_mutex_ns;
-     #endif
+    #pragma once
+    #if __cplusplus >= 201103L
+    namespace __jitify_mutex_ns {
+    class mutex {
+    public:
+    void lock();
+    bool try_lock();
+    void unlock();
+    };
+    // namespace __jitify_mutex_ns
+    namespace std { using namespace __jitify_mutex_ns; }
+    using namespace __jitify_mutex_ns;
+    #endif
  )";
 
 static const char* jitsafe_headers[] = {

--- a/jitify.hpp
+++ b/jitify.hpp
@@ -685,14 +685,17 @@ inline std::string demangle(const char* mangled_name) {
   char *demangled_ptr = abi::__cxa_demangle(mangled_name, buf, &bufsize, &status);
   if (status == 0) {
     demangled_name = demangled_ptr; // all worked as expected
+    free(buf);
   } else if (status == -2) {
     demangled_name = mangled_name;  // we interpret this as plain C name
+    free(buf);
   } else if (status == -1) {
+    free(buf);
     throw std::runtime_error(std::string("memory allocation failure in __cxa_demangle"));
   } else if (status == -3) {
+    free(buf);
     throw std::runtime_error(std::string("invalid argument to __cxa_demangle"));
   }
-  free(buf);
   return demangled_name;
 }
 #endif

--- a/jitify.hpp
+++ b/jitify.hpp
@@ -1196,7 +1196,7 @@ static const char* jitsafe_header_type_traits = R"(
     template<bool B, class T = void> struct enable_if {};
     template<class T>                struct enable_if<true, T> { typedef T type; };
     #if __cplusplus >= 201402L
-    template< bool B, class T = void > using enable_if_t = typename enable_if<B,T>::type
+    template< bool B, class T = void > using enable_if_t = typename enable_if<B,T>::type;
     #endif
 
     struct true_type  {
@@ -1255,9 +1255,6 @@ static const char* jitsafe_header_type_traits = R"(
     template<class> struct is_function : false_type { };
     template<class Ret, class... Args> struct is_function<Ret(Args...)> : true_type {}; //regular
     template<class Ret, class... Args> struct is_function<Ret(Args......)> : true_type {}; // variadic
-    #if __cplusplus >= 201402L
-    template< class T > inline constexpr bool is_function_v = is_function<T>::value;
-    #endif
 
     template<class> struct result_of;
     template<class F, typename... Args>
@@ -1305,7 +1302,7 @@ static const char* jitsafe_header_type_traits = R"(
     }
     template< class T > struct add_pointer : __jitify_detail::add_pointer<T, is_function<T>::value> {};
     #if __cplusplus >= 201402L
-    template< class T > using add_pointer_t = typename add_pointer<T>::type
+    template< class T > using add_pointer_t = typename add_pointer<T>::type;
     #endif
 
     template< class T > struct decay {


### PR DESCRIPTION
This pull request extends the support of `type_traits`, by adding initial support for the following C++11 features (except where noted they are C++14)
* `enable_if_t` (C++14)
* `is_integral`
* `is_signed`
* `is_unsigned`
* `is_array`
* `is_function`
* `remove_reference`
* `remove_reference_t`
* `remove_extent`
* `remove_extent_t` (C++14)
* `remove_const`
* `remove_const_t` (C++14)
* `remove_volatile`
* `remove_volatile_t` (C++14)
* `remove_cv`
* `remove_cv_t` (C++14)
* `conditional`
* `conditional_t` (C++14)
* `add_pointer`
* `add_pointer_t` (C++14)
* `decay`
* `decay_t` (C++14)

Moreover, the pull request also:
* Adds a mutex skeleton header for aiding cub compilation
* Adds proper error handling to `abi::__cxa_demangle` function call
* Adds CUDA arch detection during initial iterative compilation to ensure that correct internal intrinsics are included

