### PR TITLE
Feature/constant

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2017, NVIDIA Corporation
+Copyright (c) 2017-2019, NVIDIA Corporation
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/example_headers/constant_header.cuh
+++ b/example_headers/constant_header.cuh
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ * * Neither the name of NVIDIA CORPORATION nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace {
+
+  namespace b { __constant__ int a[3]; }
+
+}
+
+__global__ void constant_test2(int *x) {
+  for (int i=0; i<3; i++) x[i] = (b::a[i]);
+}

--- a/example_headers/constant_header.cuh
+++ b/example_headers/constant_header.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/example_headers/my_header1.cuh
+++ b/example_headers/my_header1.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/example_headers/my_header2.cuh
+++ b/example_headers/my_header2.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/example_headers/my_header3.cuh
+++ b/example_headers/my_header3.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/jitify.hpp
+++ b/jitify.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -966,7 +966,6 @@ class CUDAKernel {
   inline void create_constant() {
     size_t pos = 0;
     while (pos < _ptx.size()) {
-      // find any constants
       pos = _ptx.find(".const .align", pos);
       if (pos == std::string::npos) break;
       size_t end = _ptx.find(";", pos);

--- a/jitify_example.cpp
+++ b/jitify_example.cpp
@@ -210,7 +210,7 @@ bool test_constant() {
   dim3 grid(1);
   dim3 block(1);
   {  // test __constant__ look up in kernel string using diffrent namespaces
-    const char* const_program = R"(
+    const char* const_program = R"(const_program
     #pragma once
 
     __constant__ int a;

--- a/jitify_example.cpp
+++ b/jitify_example.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/stringify.cpp
+++ b/stringify.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions


### PR DESCRIPTION
This pull request adds support for `__constant__` lookup, to allow for their use in jitify kernels.  This is done so by using the `get_constant_ptr` method from a jitify kernel instance.  Behind the scenes, when the ptx kernel is created, the ptx is scanned for any `__constant__` definitions, and a map created, mapping from the variable name, and the mangled name used in the ptx source.

The test code has been updated to demonstrate this in action, showing both `__constant__` variable embedded in namespaces and array variables.

This pull also updates the copyright information to reflect the present year of 2019.

Closes #25 