### PR TITLE
Feature/linker log

### DIFF
--- a/jitify.hpp
+++ b/jitify.hpp
@@ -134,6 +134,7 @@
 #define JITIFY_PRINT_SOURCE 1
 #define JITIFY_PRINT_LOG 1
 #define JITIFY_PRINT_PTX 1
+#define JITIFY_PRINT_LINKER_LOG 1
 #define JITIFY_PRINT_LAUNCH 1
 #endif
 
@@ -900,6 +901,11 @@ class CUDAKernel {
   std::string _ptx;
   std::map<std::string, std::string> _constant;
   std::vector<CUjit_option> _opts;
+  std::vector<void*> _optvals;
+#ifdef JITIFY_PRINT_LINKER_LOG
+  char info_log[8192];
+  unsigned int logSize = 8192;
+#endif
 
   inline void cuda_safe_call(CUresult res) const {
     if (res != CUDA_SUCCESS) {
@@ -909,14 +915,16 @@ class CUDAKernel {
     }
   }
   inline void create_module(std::vector<std::string> link_files,
-                            std::vector<std::string> link_paths,
-                            void** optvals = 0) {
+                            std::vector<std::string> link_paths) {
+#ifndef JITIFY_PRINT_LINKER_LOG
+    // WAR since linker log does not seem to be constructed using a single call to cuModuleLoadDataEx
     if (link_files.empty()) {
       cuda_safe_call(cuModuleLoadDataEx(&_module, _ptx.c_str(), _opts.size(),
-                                        _opts.data(), optvals));
-    } else {
-      cuda_safe_call(
-          cuLinkCreate(_opts.size(), _opts.data(), optvals, &_link_state));
+                                        _opts.data(), _optvals.data()));
+    } else
+#endif
+    {
+      cuda_safe_call(cuLinkCreate(_opts.size(), _opts.data(), _optvals.data(), &_link_state));
       cuda_safe_call(cuLinkAddData(_link_state, CU_JIT_INPUT_PTX,
                                    (void*)_ptx.c_str(), _ptx.size(),
                                    "jitified_source.ptx", 0, 0, 0));
@@ -949,6 +957,13 @@ class CUDAKernel {
       cuda_safe_call(cuLinkComplete(_link_state, &cubin, &cubin_size));
       cuda_safe_call(cuModuleLoadData(&_module, cubin));
     }
+#ifdef JITIFY_PRINT_LINKER_LOG
+    std::cout << "---------------------------------------" << std::endl;
+    std::cout << "--- Linker for " << reflection::detail::demangle(_func_name.c_str()) << " ---" << std::endl;
+    std::cout << "---------------------------------------" << std::endl;
+    std::cout << info_log << std::endl;
+    std::cout << "---------------------------------------" << std::endl;
+#endif
     cuda_safe_call(cuModuleGetFunction(&_kernel, _module, _func_name.c_str()));
   }
   inline void destroy_module() {
@@ -1002,8 +1017,17 @@ class CUDAKernel {
         _kernel(0),
         _func_name(func_name),
         _ptx(ptx),
-        _opts(opts, opts + nopts) {
-    this->create_module(link_files, link_paths, optvals);
+        _opts(opts, opts + nopts),
+        _optvals(optvals, optvals + nopts) {
+#ifdef JITIFY_PRINT_LINKER_LOG
+    _opts.push_back(CU_JIT_INFO_LOG_BUFFER);
+    _optvals.push_back((void *) info_log);
+    _opts.push_back(CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES);
+    _optvals.push_back((void *) (long)logSize);
+    _opts.push_back(CU_JIT_LOG_VERBOSE);
+    _optvals.push_back((void *)1);
+#endif
+    this->create_module(link_files, link_paths);
     this->create_constant();
   }
   inline CUDAKernel& set(const char* func_name, const char* ptx,
@@ -1017,7 +1041,15 @@ class CUDAKernel {
     _link_files = link_files;
     _link_paths = link_paths;
     _opts.assign(opts, opts + nopts);
-    this->create_module(link_files, link_paths, optvals);
+#ifdef JITIFY_PRINT_LINKER_LOG
+    _opts.push_back(CU_JIT_INFO_LOG_BUFFER);
+    _optvals.push_back((void *) info_log);
+    _opts.push_back(CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES);
+    _optvals.push_back((void *) (long)logSize);
+    _opts.push_back(CU_JIT_LOG_VERBOSE);
+    _optvals.push_back((void *)1);
+#endif
+    this->create_module(link_files, link_paths);
     this->create_constant();
     return *this;
   }
@@ -2532,11 +2564,9 @@ inline void KernelInstantiation_impl::build_kernel() {
 
 #if JITIFY_PRINT_PTX
   std::cout << "---------------------------------------" << std::endl;
-  std::cout << mangled_instantiation << std::endl;
+  std::cout << "--- PTX for " << mangled_instantiation << " in " << program.name() << " ---" << std::endl;
   std::cout << "---------------------------------------" << std::endl;
-  std::cout << "--- PTX for " << program.name() << " ---" << std::endl;
-  std::cout << "---------------------------------------" << std::endl;
-  std::cout << ptx << std::endl;
+  std::cout << ptx;
   std::cout << "---------------------------------------" << std::endl;
 #endif
 

--- a/jitify_example.cpp
+++ b/jitify_example.cpp
@@ -35,6 +35,7 @@
 #define JITIFY_PRINT_SOURCE 1
 #define JITIFY_PRINT_LOG 1
 #define JITIFY_PRINT_PTX 1
+#define JITIFY_PRINT_LINKER_LOG 1
 #define JITIFY_PRINT_LAUNCH 1
 #include "jitify.hpp"
 


### PR DESCRIPTION
This pull request adds a new verbosity macro `JITIFY_PRINT_LINKER_LOG` which when enabled prints out any log generated by the linking step of the compilation (which includes the ptxas compiler).  Hence, enabling this will reveal the register / shared-memory / local memory / stack frame allocation of a given kernel.

E.g.,

```
---------------------------------------
--- Source of my_program ---
---------------------------------------
  1 template<int N, typename T>
  2 __global__
  3 void my_kernel(T* data) {
  4     T data0 = data[0];
  5     for( int i=0; i<N-1; ++i ) {
  6         data[0] *= data0;
  7     }
  8 }
---------------------------------------
Building my_kernel<(int)3,float > [-arch=compute_60]
---------------------------------------
--- PTX for _Z9my_kernelILi3EfEvPT0_ in my_program ---
---------------------------------------
//
// Generated by NVIDIA NVVM Compiler
//
// Compiler Build ID: CL-26218862
// Cuda compilation tools, release 10.1, V10.1.168
// Based on LLVM 3.4svn
//

.version 6.4
.target sm_60
.address_size 64

	// .weak	_Z9my_kernelILi3EfEvPT0_

.weak .entry _Z9my_kernelILi3EfEvPT0_(
	.param .u64 _Z9my_kernelILi3EfEvPT0__param_0
)
{
	.reg .f32 	%f<4>;
	.reg .b64 	%rd<3>;


	ld.param.u64 	%rd1, [_Z9my_kernelILi3EfEvPT0__param_0];
	cvta.to.global.u64 	%rd2, %rd1;
	ld.global.f32 	%f1, [%rd2];
	mul.f32 	%f2, %f1, %f1;
	mul.f32 	%f3, %f1, %f2;
	st.global.f32 	[%rd2], %f3;
	ret;
}


---------------------------------------
---------------------------------------
--- Linker for void my_kernel<3, float>(float*) ---
---------------------------------------
info    : 0 bytes gmem
info    : Function properties for '_Z9my_kernelILi3EfEvPT0_':
info    : used 6 registers, 0 stack, 0 bytes smem, 328 bytes cmem[0], 0 bytes lmem
---------------------------------------
Launching my_kernel<(int)3,float ><<<1,1,0,0>>>(float*)
```

This pull depends on #27, so that pull should be merged before this.