### PR TITLE
Fix a collection of issues related to Windows/MSVC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 DOXYGEN ?= doxygen
-CXXFLAGS ?= -O3 -Wall -g -fmessage-length=80
+CXXFLAGS ?= -O3 -Wall -Wconversion -g -fmessage-length=80
 
 CXX11 ?= 1
 
@@ -71,7 +71,7 @@ CUB_INC = -I$(CUB_DIR)
 JITIFY_TEST_DEFINES = -DCUDA_INC_DIR="\"$(CUDA_INC_DIR)\"" -DCUB_DIR="\"$(CUB_DIR)\""
 
 jitify_test: jitify_test.cpp $(HEADERS) $(GTEST_STATIC_LIB) $(CUB_HEADER)
-	$(CXX) -o $@ $< -std=c++11 -O3 -Wall $(JITIFY_TEST_DEFINES) $(INC) $(GTEST_INC) $(CUB_INC) $(LIB) $(GTEST_LIB)
+	$(CXX) -o $@ $< -std=c++11 $(CXXFLAGS) $(JITIFY_TEST_DEFINES) $(INC) $(GTEST_INC) $(CUB_INC) $(LIB) $(GTEST_LIB)
 
 test: jitify_test
 	./jitify_test

--- a/jitify.hpp
+++ b/jitify.hpp
@@ -807,7 +807,7 @@ struct type_reflection {
     //         return ret;
     //#endif
   }
-};
+};  // namespace detail
 template <typename T, T VALUE>
 struct type_reflection<NonType<T, VALUE> > {
   inline static std::string name() {
@@ -2023,7 +2023,7 @@ inline void add_options_from_env(std::vector<std::string>& options) {
   }
 #undef JITIFY_TOSTRING
 #undef JITIFY_TOSTRING_IMPL
-#endif
+#endif  // JITIFY_OPTIONS
 }
 
 inline void detect_and_add_cuda_arch(std::vector<std::string>& options) {

--- a/jitify.hpp
+++ b/jitify.hpp
@@ -90,6 +90,7 @@
 #endif
 #include <stdint.h>
 #include <algorithm>
+#include <cctype>
 #include <cstring>  // For strtok_r etc.
 #include <deque>
 #include <fstream>

--- a/jitify.hpp
+++ b/jitify.hpp
@@ -2124,12 +2124,14 @@ inline std::string ptx_parse_decl_name(const std::string& line) {
   size_t name_end = line.find_first_of("[;");
   if (name_end == std::string::npos) {
     throw std::runtime_error(
-        "Failed to parse .global declaration in PTX: expected a semicolon");
+        "Failed to parse .global/.const declaration in PTX: expected a "
+        "semicolon");
   }
   size_t name_start_minus1 = line.find_last_of(" \t", name_end);
   if (name_start_minus1 == std::string::npos) {
     throw std::runtime_error(
-        "Failed to parse .global declaration in PTX: expected whitespace");
+        "Failed to parse .global/.const declaration in PTX: expected "
+        "whitespace");
   }
   size_t name_start = name_start_minus1 + 1;
   std::string name = line.substr(name_start, name_end - name_start);
@@ -2147,7 +2149,8 @@ inline void ptx_remove_unused_globals(std::string* ptx) {
     auto terms = split_string(line);
     if (terms.size() <= 1) continue;  // Ignore lines with no arguments
     if (terms[0].substr(0, 2) == "//") continue;  // Ignore comment lines
-    if (terms[0].substr(0, 7) == ".global") {
+    if (terms[0].substr(0, 7) == ".global" ||
+        terms[0].substr(0, 6) == ".const") {
       line_num_to_global_name.emplace(line_num, ptx_parse_decl_name(line));
       continue;
     }

--- a/jitify.hpp
+++ b/jitify.hpp
@@ -1573,9 +1573,6 @@ static const char* jitsafe_header_stddef_h =
     "#pragma once\n"
     "#include <climits>\n"
     "namespace __jitify_stddef_ns {\n"
-    //"enum { NULL = 0 };\n"
-    "typedef unsigned long size_t;\n"
-    "typedef   signed long ptrdiff_t;\n"
     "#if __cplusplus >= 201103L\n"
     "typedef decltype(nullptr) nullptr_t;\n"
     "#if defined(_MSC_VER)\n"
@@ -1596,7 +1593,12 @@ static const char* jitsafe_header_stddef_h =
     "enum class byte : unsigned char {};\n"
     "#endif  // __cplusplus >= 201703L\n"
     "} // namespace __jitify_stddef_ns\n"
-    "namespace std { using namespace __jitify_stddef_ns; }\n"
+    "namespace std {\n"
+    "  // NVRTC provides built-in definitions of ::size_t and ::ptrdiff_t.\n"
+    "  using ::size_t;\n"
+    "  using ::ptrdiff_t;\n"
+    "  using namespace __jitify_stddef_ns;\n"
+    "} // namespace std\n"
     "using namespace __jitify_stddef_ns;\n";
 
 static const char* jitsafe_header_stdlib_h =
@@ -1912,8 +1914,6 @@ static const char* jitsafe_header_time_h = R"(
     #define NULL 0
     #define CLOCKS_PER_SEC 1000000
     namespace __jitify_time_ns {
-    typedef unsigned long size_t;
-    typedef long clock_t;
     typedef long time_t;
     struct tm {
       int tm_sec;
@@ -1933,7 +1933,12 @@ static const char* jitsafe_header_time_h = R"(
     };
     #endif
     }  // namespace __jitify_time_ns
-    namespace std { using namespace __jitify_time_ns; }
+    namespace std {
+      // NVRTC provides built-in definitions of ::size_t and ::clock_t.
+      using ::size_t;
+      using ::clock_t;
+      using namespace __jitify_time_ns;
+    }
     using namespace __jitify_time_ns;
  )";
 

--- a/jitify.hpp
+++ b/jitify.hpp
@@ -2274,9 +2274,9 @@ inline nvrtcResult compile_kernel(std::string program_name,
     std::vector<char> vlog(logsize, 0);
     CHECK_NVRTC(nvrtcGetProgramLog(nvrtc_program, vlog.data()));
     log->assign(vlog.data(), logsize);
-    if (ret != NVRTC_SUCCESS) {
-      return ret;
-    }
+  }
+  if (ret != NVRTC_SUCCESS) {
+    return ret;
   }
 
   if (ptx) {

--- a/jitify.hpp
+++ b/jitify.hpp
@@ -92,13 +92,6 @@
 #define __cplusplus _MSVC_LANG
 #endif
 
-#if defined(_WIN32) || defined(_WIN64)
-// WAR for strtok_r being called strtok_s on Windows
-#pragma push_macro("strtok_r")
-#undef strtok_r
-#define strtok_r strtok_s
-#endif
-
 #include <dlfcn.h>
 #include <stdint.h>
 #include <algorithm>
@@ -126,6 +119,18 @@
 #define NVRTC_GET_TYPE_NAME 1
 #endif
 #include <nvrtc.h>
+
+#if defined(_WIN32) || defined(_WIN64)
+// WAR for strtok_r being called strtok_s on Windows
+#pragma push_macro("strtok_r")
+#undef strtok_r
+#define strtok_r strtok_s
+// WAR for min and max possibly being macros defined by windows.h
+#pragma push_macro("min")
+#pragma push_macro("max")
+#undef min
+#undef max
+#endif
 
 #ifndef JITIFY_PRINT_LOG
 #define JITIFY_PRINT_LOG 1
@@ -3811,6 +3816,8 @@ inline KernelLauncher KernelInstantiation::configure_1d_max_occupancy(
 }  // namespace jitify
 
 #if defined(_WIN32) || defined(_WIN64)
+#pragma pop_macro("max")
+#pragma pop_macro("min")
 #pragma pop_macro("strtok_r")
 #endif
 

--- a/jitify.hpp
+++ b/jitify.hpp
@@ -993,13 +993,14 @@ class CUDAKernel {
     // WAR since linker log does not seem to be constructed using a single call
     // to cuModuleLoadDataEx.
     if (link_files.empty()) {
-      cuda_safe_call(cuModuleLoadDataEx(&_module, _ptx.c_str(), _opts.size(),
-                                        _opts.data(), _optvals.data()));
+      cuda_safe_call(cuModuleLoadDataEx(&_module, _ptx.c_str(),
+                                        (unsigned)_opts.size(), _opts.data(),
+                                        _optvals.data()));
     } else
 #endif
     {
-      cuda_safe_call(cuLinkCreate(_opts.size(), _opts.data(), _optvals.data(),
-                                  &_link_state));
+      cuda_safe_call(cuLinkCreate((unsigned)_opts.size(), _opts.data(),
+                                  _optvals.data(), &_link_state));
       cuda_safe_call(cuLinkAddData(_link_state, CU_JIT_INPUT_PTX,
                                    (void*)_ptx.c_str(), _ptx.size(),
                                    "jitified_source.ptx", 0, 0, 0));
@@ -1953,8 +1954,8 @@ static const char* preinclude_jitsafe_header_names[] = {
     "time.h",
 };
 
-template <class T, size_t N>
-size_t array_size(T (&)[N]) {
+template <class T, int N>
+int array_size(T (&)[N]) {
   return N;
 }
 const int preinclude_jitsafe_headers_count =

--- a/jitify_example.cpp
+++ b/jitify_example.cpp
@@ -306,7 +306,7 @@ bool test_parallel_for() {
   T val = 3.14159f;
 
   jitify::ExecutionPolicy policy(jitify::DEVICE);
-  auto lambda = JITIFY_LAMBDA((d_out, val), d_out[i] = i * val);
+  auto lambda = JITIFY_LAMBDA((d_out, val), d_out[i] = (T)i * val);
   CHECK_CUDA(jitify::parallel_for(policy, 0, n, lambda));
 
   std::vector<T> h_out(n);
@@ -315,8 +315,8 @@ bool test_parallel_for() {
   cudaFree(d_out);
 
   for (int i = 0; i < n; ++i) {
-    if (!are_close(h_out[i], i * val)) {
-      std::cout << h_out[i] << " != " << i * val << std::endl;
+    if (!are_close(h_out[i], (T)i * val)) {
+      std::cout << h_out[i] << " != " << (T)i * val << std::endl;
       return false;
     }
   }

--- a/jitify_example.cpp
+++ b/jitify_example.cpp
@@ -81,8 +81,6 @@ std::istream* file_callback(std::string filename, std::iostream& tmp_stream) {
   }
 }
 
-#if __cplusplus >= 201103L
-
 template <typename T>
 bool test_simple() {
   const char* program_source =
@@ -322,10 +320,7 @@ bool test_parallel_for() {
   return true;
 }
 
-#endif  // C++11
-
 int main(int argc, char* argv[]) {
-#if __cplusplus >= 201103L
 #define TEST_RESULT(result) (result ? "PASSED" : "FAILED")
 
   // Uncached
@@ -355,9 +350,4 @@ int main(int argc, char* argv[]) {
   return (!test_simple_result + !test_simple_experimental_result +
           !test_kernels_result + !test_parallel_for_result +
           !test_constant_result);
-#else
-  std::cout << "Tests require building with C++11 support (make CXX11=1)"
-            << std::endl;
-  return 0;
-#endif
 }

--- a/jitify_example.cpp
+++ b/jitify_example.cpp
@@ -31,6 +31,9 @@
     and call kernels.
  */
 
+#ifdef LINUX  // Only supported by gcc on Linux (defined in Makefile)
+#define JITIFY_ENABLE_EMBEDDED_FILES 1
+#endif
 #define JITIFY_PRINT_INSTANTIATION 1
 #define JITIFY_PRINT_SOURCE 1
 #define JITIFY_PRINT_LOG 1
@@ -40,7 +43,7 @@
 #include "jitify.hpp"
 
 #include "example_headers/my_header1.cuh.jit"
-#ifdef LINUX  // Only supported by gcc on Linux
+#ifdef LINUX  // Only supported by gcc on Linux (defined in Makefile)
 JITIFY_INCLUDE_EMBEDDED_FILE(example_headers_my_header2_cuh);
 #endif
 

--- a/jitify_test.cpp
+++ b/jitify_test.cpp
@@ -646,6 +646,22 @@ TEST(JitifyTest, RemoveUnusedGlobals) {
   CHECK_CUDART(cudaFree(d_data));
 }
 
+static const char* const curand_program_source =
+    "curand_program\n"
+    "#include <curand_kernel.h>\n"
+    "__global__ void my_kernel() {}\n"
+    "\n";
+
+TEST(JitifyTest, CuRandKernel) {
+  auto program_v2 = jitify::experimental::Program(
+      curand_program_source, {},
+      // Note: --remove-unused-globals is added to remove huge precomputed
+      // arrays that come from CURAND.
+      {"-I" CUDA_INC_DIR, "--remove-unused-globals"});
+  auto kernel_inst_v2 = program_v2.kernel("my_kernel").instantiate();
+  // TODO: Expand this test to actually call curand kernels and check outputs.
+}
+
 // NOTE: Keep this as the last test in the file, in case the env var is sticky.
 TEST(JitifyTest, EnvVarOptions) {
   setenv("JITIFY_OPTIONS", "-bad_option", true);

--- a/jitify_test.cpp
+++ b/jitify_test.cpp
@@ -447,7 +447,7 @@ TEST(JitifyTest, ParallelFor) {
   T val = 3.14159f;
 
   jitify::ExecutionPolicy policy(jitify::DEVICE);
-  auto lambda = JITIFY_LAMBDA((d_out, val), d_out[i] = i * val);
+  auto lambda = JITIFY_LAMBDA((d_out, val), d_out[i] = (float)i * val);
   CHECK_CUDA(jitify::parallel_for(policy, 0, n, lambda));
 
   std::vector<T> h_out(n);
@@ -457,7 +457,7 @@ TEST(JitifyTest, ParallelFor) {
   CHECK_CUDART(cudaFree(d_out));
 
   for (int i = 0; i < n; ++i) {
-    EXPECT_FLOAT_EQ(h_out[i], i * val);
+    EXPECT_FLOAT_EQ(h_out[i], (T)i * val);
   }
 }
 
@@ -545,7 +545,7 @@ TEST(JitifyTest, CubBlockPrimitives) {
   float sum = 0;
   for (int i = 0; i < n; ++i) {
     // Start with values sorted in reverse.
-    h_data[i] = n - 1 - i;
+    h_data[i] = (float)(n - 1 - i);
     sum += h_data[i];
   }
   // Shuffle the values a bit.
@@ -554,7 +554,7 @@ TEST(JitifyTest, CubBlockPrimitives) {
   std::vector<float> h_expected(n);
   for (int i = 0; i < n; ++i) {
     // Expected sorted and normalized.
-    h_expected[i] = i / sum;
+    h_expected[i] = (float)i / sum;
   }
   std::vector<float> h_result(n);
   float* d_data;

--- a/jitify_test.cpp
+++ b/jitify_test.cpp
@@ -26,6 +26,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef LINUX  // Only supported by gcc on Linux (defined in Makefile)
+#define JITIFY_ENABLE_EMBEDDED_FILES 1
+#endif
 #define JITIFY_PRINT_INSTANTIATION 1
 #define JITIFY_PRINT_SOURCE 1
 #define JITIFY_PRINT_LOG 1
@@ -36,7 +39,7 @@
 #include "jitify.hpp"
 
 #include "example_headers/my_header1.cuh.jit"
-#ifdef LINUX  // Only supported by gcc on Linux
+#ifdef LINUX  // Only supported by gcc on Linux (defined in Makefile)
 JITIFY_INCLUDE_EMBEDDED_FILE(example_headers_my_header2_cuh);
 #endif
 


### PR DESCRIPTION
Fixes issues found in https://github.com/NVIDIA/jitify/issues/43 (along with a few other minor things that were noticed along the way).

The main fixes relate to: min/max macros, __cplusplus macro, dlfcn dependency, incompatible size_t definition, and incorrect name demangling.

Full details are in the commit messages.