### PR TITLE
Add get_global_ptr and improve linker functionality

### DIFF
--- a/example_headers/constant_header.cuh
+++ b/example_headers/constant_header.cuh
@@ -30,10 +30,11 @@
 
 namespace {
 
-  namespace b { __constant__ int a[3]; }
+  namespace b { __constant__ int a[3]; __device__ int d[3]; }
 
 }
 
 __global__ void constant_test2(int *x) {
   for (int i=0; i<3; i++) x[i] = (b::a[i]);
+  for (int i=0; i<3; i++) x[i + 3] = (b::d[i]);
 }

--- a/jitify.hpp
+++ b/jitify.hpp
@@ -2204,7 +2204,7 @@ inline void ptx_remove_unused_globals(std::string* ptx) {
       const char* token_delims = " \t()[]{},;+-*/~&|^?:=!<>\"'\\";
       for (auto token : split_string(terms[i], -1, token_delims)) {
         if (  // Ignore non-names
-            !(std::isalpha(token[0]) || token[0] == '_') ||
+            !(std::isalpha(token[0]) || token[0] == '_' || token[0] == '$') ||
             token.find('.') != std::string::npos ||
             // Ignore variable/parameter declarations
             terms[i - 1][0] == '.' ||

--- a/jitify.hpp
+++ b/jitify.hpp
@@ -1084,7 +1084,12 @@ class CUDAKernel {
     std::cout << "---------------------------------------" << std::endl;
 #endif
     cuda_safe_call(result);
-    cuda_safe_call(cuModuleGetFunction(&_kernel, _module, _func_name.c_str()));
+    // Allow _func_name to be empty to support cases where we want to generate
+    // PTX containing extern symbol definitions but no kernels.
+    if (!_func_name.empty()) {
+      cuda_safe_call(
+          cuModuleGetFunction(&_kernel, _module, _func_name.c_str()));
+    }
   }
   inline void destroy_module() {
     if (_link_state) {

--- a/jitify_test.cpp
+++ b/jitify_test.cpp
@@ -613,6 +613,7 @@ static const char* const unused_globals_source =
     "  used_struct.b = 3.f;\n"
     "  __syncthreads();\n"
     "  *data += Foo::value + used_scalar + used_array[1] + used_struct.b;\n"
+  "  printf(\"*data = %i\\n\", *data);\n"  // Produces global symbols named $str
     "}\n";
 
 TEST(JitifyTest, RemoveUnusedGlobals) {

--- a/jitify_test.cpp
+++ b/jitify_test.cpp
@@ -693,9 +693,9 @@ TEST(JitifyTest, CuRandKernel) {
 
 static const char* const linktest_program1_source =
     "linktest_program1\n"
-    "extern __constant__ int c = 5;\n"
-    "extern __device__ int d = 7;\n"
-    "extern __device__ int f(int i) { return i + 11; }\n"
+    "__constant__ int c = 5;\n"
+    "__device__ int d = 7;\n"
+    "__device__ int f(int i) { return i + 11; }\n"
     "\n";
 
 static const char* const linktest_program2_source =


### PR DESCRIPTION
Adds get_global_ptr as a more general version of get_constant_ptr, and improves linker support including better error logging and support for different file types. Relevant to https://github.com/NVIDIA/jitify/issues/46.

Also fixes a small bug in -remove-unused-globals.

Full details in commit log.