### PR TITLE
fix for C4706 warning

### DIFF
--- a/jitify.hpp
+++ b/jitify.hpp
@@ -576,7 +576,7 @@ inline bool load_source(
     std::string fullpath = path_join(current_dir, filename);
     // Try loading from callback
     if (!file_callback ||
-        !(source_stream = file_callback(fullpath, string_stream))) {
+        !((source_stream = file_callback(fullpath, string_stream)) != 0)) {
 #if JITIFY_ENABLE_EMBEDDED_FILES
       // Try loading as embedded file
       EmbeddedData embedded;


### PR DESCRIPTION
Simple fix for C4760 warning as a result of assignment in a conditional. See MS notes: https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4706?view=vs-2019