### PR TITLE
Launch functions should accept rvalue references not lvalue reference

### DIFF
--- a/jitify.hpp
+++ b/jitify.hpp
@@ -804,7 +804,7 @@ inline std::string demangle_native_type(const std::type_info& typeinfo) {
   }
   throw std::runtime_error("UnDecorateSymbolName failed");
 }
-#else   // not MSVC
+#else  // not MSVC
 inline std::string demangle_cuda_symbol(const char* mangled_name) {
   size_t bufsize = 0;
   char* buf = nullptr;
@@ -3063,28 +3063,26 @@ class KernelLauncher {
    *  \see launch
    */
   template <typename... ArgTypes>
-  inline CUresult operator()(ArgTypes&&... args) const {
-    return this->launch(std::forward<ArgTypes>(args)...);
+  inline CUresult operator()(const ArgTypes&... args) const {
+    return this->launch(args...);
   }
   /*! Launch the kernel.
    *
    *  \param args Function arguments for the kernel.
    */
   template <typename... ArgTypes>
-  inline CUresult launch(ArgTypes&&... args) const {
-    return this->launch(
-        std::vector<void*>({(void*)&std::forward<ArgTypes>(args)...}),
-        {reflection::reflect<ArgTypes>()...});
+  inline CUresult launch(const ArgTypes&... args) const {
+    return this->launch(std::vector<void*>({(void*)&args...}),
+                        {reflection::reflect<ArgTypes>()...});
   }
   /*! Launch the kernel and check for cuda errors.
    *
    *  \param args Function arguments for the kernel.
    */
   template <typename... ArgTypes>
-  inline void safe_launch(ArgTypes&&... args) const {
-    this->safe_launch(
-        std::vector<void*>({(void*)&std::forward<ArgTypes>(args)...}),
-        {reflection::reflect<ArgTypes>()...});
+  inline void safe_launch(const ArgTypes&... args) const {
+    this->safe_launch(std::vector<void*>({(void*)&args...}),
+                      {reflection::reflect<ArgTypes>()...});
   }
 };
 
@@ -4292,10 +4290,9 @@ class KernelLauncher {
    *  \param args Function arguments for the kernel.
    */
   template <typename... ArgTypes>
-  CUresult launch(ArgTypes&&... args) const {
-    return this->launch(
-        std::vector<void*>({(void*)&std::forward<ArgTypes>(args)...}),
-        {reflection::reflect<ArgTypes>()...});
+  CUresult launch(const ArgTypes&... args) const {
+    return this->launch(std::vector<void*>({(void*)&args...}),
+                        {reflection::reflect<ArgTypes>()...});
   }
 
   /*! Launch the kernel and check for cuda errors.
@@ -4303,10 +4300,9 @@ class KernelLauncher {
    *  \param args Function arguments for the kernel.
    */
   template <typename... ArgTypes>
-  void safe_launch(ArgTypes&&... args) const {
-    return this->safe_launch(
-        std::vector<void*>({(void*)&std::forward<ArgTypes>(args)...}),
-        {reflection::reflect<ArgTypes>()...});
+  void safe_launch(const ArgTypes&... args) const {
+    return this->safe_launch(std::vector<void*>({(void*)&args...}),
+                             {reflection::reflect<ArgTypes>()...});
   }
 };
 

--- a/jitify_test.cu
+++ b/jitify_test.cu
@@ -920,8 +920,20 @@ TEST(JitifyTest, ClassKernelArg) {
     EXPECT_EQ(arg.x, h_data);
   }
 
+  {  // test that we can pass an arg object rvalue to a kernel
+    int value = -2;
+    CHECK_CUDA(program.kernel("class_arg_kernel")
+                   .instantiate(Type<Arg>())
+                   .configure(grid, block)
+                   .launch(d_data, Arg(value)));
+    CHECK_CUDART(cudaDeviceSynchronize());
+    CHECK_CUDART(
+        cudaMemcpy(&h_data, d_data, sizeof(int), cudaMemcpyDeviceToHost));
+    EXPECT_EQ(value, h_data);
+  }
+
   {  // test that we can pass an arg object reference to a kernel
-    Arg* arg = new Arg(-1);
+    Arg* arg = new Arg(-3);
     // references are passed as pointers since refernces are just pointers from
     // an ABI point of view
     CHECK_CUDA(program.kernel("class_arg_ref_kernel")
@@ -935,7 +947,7 @@ TEST(JitifyTest, ClassKernelArg) {
   }
 
   {  // test that we can pass an arg object reference to a kernel
-    Arg* arg = new Arg(-1);
+    Arg* arg = new Arg(-4);
     CHECK_CUDA(program.kernel("class_arg_ptr_kernel")
                    .instantiate(Type<Arg>())
                    .configure(grid, block)


### PR DESCRIPTION
This PR modifies the `launch` and `safe_launch` kernel launch functions to pass arguments as rvalues not lvalues.  This enables us (again) to pass rvalue temporaries to the launch function, and fixes this regression introduced in #71.

Extends the `ClassKernelArg` tests to include passing a const ref to the launch function to ensure this regression doesn't happen again.