### PR TITLE
detail::path_base() now supports both path seperators on Windows.

### DIFF
--- a/jitify.hpp
+++ b/jitify.hpp
@@ -365,7 +365,7 @@ inline std::string path_base(std::string p) {
   // "foo/bar"  -> "foo"
   // "foo/bar/" -> "foo/bar"
 #if defined _WIN32 || defined _WIN64
-  char sep = '\\';
+  const char* sep = "\\/";
 #else
   char sep = '/';
 #endif


### PR DESCRIPTION
Have tested that it fixes the problem reported in #87.

`std::string;:npos` is the unsigned value of `-1`, so can't just use `std::max` without some nasty casting.

Closes #87