### PR TITLE
Do not depend on global states on string manipulation

### DIFF
--- a/jitify.hpp
+++ b/jitify.hpp
@@ -496,10 +496,13 @@ inline std::string comment_out_code_line(int line_num, std::string source) {
 inline void print_with_line_numbers(std::string const& source) {
   int linenum = 1;
   std::stringstream source_ss(source);
+  std::stringstream output_ss;
+  output_ss.imbue(std::locale::classic());
   for (std::string line; std::getline(source_ss, line); ++linenum) {
-    std::cout << std::setfill(' ') << std::setw(3) << linenum << " " << line
+    output_ss << std::setfill(' ') << std::setw(3) << linenum << " " << line
               << std::endl;
   }
+  std::cout << output_ss.str();
 }
 
 inline void print_compile_log(std::string program_name,
@@ -693,6 +696,7 @@ inline bool load_source(
   //   of the same header from different paths.
   if (pragma_once) {
     std::stringstream ss;
+    ss.imbue(std::locale::classic());
     ss << std::uppercase << std::hex << std::setw(8) << std::setfill('0')
        << hash;
     std::string include_guard_name = "_JITIFY_INCLUDE_GUARD_" + ss.str() + "\n";


### PR DESCRIPTION
This PR changes the string manipulation to avoid depending on global states. Specifically, this fixes the issue that:

* `print_with_line_numbers` depends on the previously-set `cout` state.
* Include guard generation depends on the previously-set global locale. (found in https://github.com/cupy/cupy/issues/6134#issuecomment-974624444)

Reproducer:

```cpp
#include <locale>
#include <iostream>
#include <iomanip>
#include <string>

#include "jitify.hpp"

class comma_numpunct : public std::numpunct<char>
{
public:
   comma_numpunct(char thousands_sep, const char* grouping)
      :m_thousands_sep(thousands_sep),
       m_grouping(grouping){}
protected:
   char do_thousands_sep() const{return m_thousands_sep;}
   std::string do_grouping() const {return m_grouping;}
private:
   char m_thousands_sep;
   std::string m_grouping;
};


int main() {
    // (1) print_with_line_numbers depend on previously-set cout state
    std::cout << std::setbase(16);
    jitify::detail::print_with_line_numbers("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n");
    // -> The line numbers are shown in hex.

    // (2) include guard generation depends on previously-set global locale
    std::locale comma_locale(std::locale(), new comma_numpunct(',', "\03"));
    std::locale::global(comma_locale);

    // (Quote from Jitify's pragma_once code)
    std::stringstream ss;
    // ss.imbue(std::locale::classic());
    ss << std::uppercase << std::hex << std::setw(8) << std::setfill('0')
       << 123456789;
    std::string include_guard_name = "_JITIFY_INCLUDE_GUARD_" + ss.str() + "\n";
    std::cout << include_guard_name << std::endl;
    // -> Generates a broken include guard: "_JITIFY_INCLUDE_GUARD_7,5BC,D15"
}
```