### PR TITLE
Complete std::numeric_limits for the generic int

### DIFF
--- a/jitify.hpp
+++ b/jitify.hpp
@@ -1612,14 +1612,28 @@ struct IntegerLimits {
 #endif  // __cplusplus >= 201103L
 	enum {
        is_specialized = true,
-       digits = (Digits == -1) ? (int)(sizeof(T)*8 - (Min != 0)) : Digits,
-       digits10   = (digits * 30103) / 100000,
-       is_signed  = ((T)(-1)<0),
-       is_integer = true,
-       is_exact   = true,
-       radix      = 2,
-       is_bounded = true,
-       is_modulo  = false
+       digits            = (Digits == -1) ? (int)(sizeof(T)*8 - (Min != 0)) : Digits,
+       digits10          = (digits * 30103) / 100000,
+       is_signed         = ((T)(-1)<0),
+       is_integer        = true,
+       is_exact          = true,
+       has_infinity      = false,
+       has_quiet_NaN     = false,
+       has_signaling_NaN = false,
+       has_denorm        = 0,
+       has_denorm_loss   = false,
+       round_style       = 0,
+       is_iec559         = false,
+       is_bounded        = true,
+       is_modulo         = !(is_signed || Max == 1 /*is bool*/),
+       max_digits10      = 0,
+       radix             = 2,
+       min_exponent      = 0,
+       min_exponent10    = 0,
+       max_exponent      = 0,
+       max_exponent10    = 0,
+       tinyness_before   = false,
+       traps             = false
 	};
 };
 } // namespace __jitify_detail


### PR DESCRIPTION
These values almost all refer to floating point properties so just hold sensible defaults, however some code expects them to exist so it's better that they're included.

Values copied from: https://en.cppreference.com/w/cpp/types/numeric_limits

(Another case required to support some [GLM](https://github.com/g-truc/glm/pull/1073) functionality, where `std::numeric_limits<unsigned int>::is_iec559` was being called. Also fixed the remaining values to save finding they're required too later. Left `traps` out, as wasn't 100% sure of the appropriate value.).