### PR TITLE
Fix compilation error with MSVC 2022

### DIFF
--- a/jitify.hpp
+++ b/jitify.hpp
@@ -2711,6 +2711,8 @@ inline nvrtcResult compile_kernel(std::string program_name,
   // Ensure nvrtc_program gets destroyed.
   struct ScopedNvrtcProgramDestroyer {
     nvrtcProgram& nvrtc_program_;
+    ScopedNvrtcProgramDestroyer(nvrtcProgram& nvrtc_program)
+        : nvrtc_program_(nvrtc_program) {}    
     ~ScopedNvrtcProgramDestroyer() { nvrtcDestroyProgram(&nvrtc_program_); }
     ScopedNvrtcProgramDestroyer(const ScopedNvrtcProgramDestroyer&) = delete;
     ScopedNvrtcProgramDestroyer& operator=(const ScopedNvrtcProgramDestroyer&) =


### PR DESCRIPTION
Trying to use the latest version of Jitify with MSVC 2022 leads to the following error
` error C2440: 'initializing': cannot convert from 'initializer list' to 'jitify::detail::compile_kernel::ScopedNvrtcProgramDestroyer'`

It seems to me MSVC is actually in the wrong here, but this change is unintrusive enough that I believe it makes sense to push it.