### PR TITLE
Use dlopen/LoadLibrary to link the CUDA driver lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set (CMAKE_CUDA_STANDARD 11)  # Doesn't work?
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ")
 if (MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX")
-  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} /O2")
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /O2")
 else()
   set(CMAKE_CXX_FLAGS
       "${CMAKE_CXX_FLAGS} -O3 -Wall -Wextra -Wconversion -Wshadow")
@@ -20,7 +20,7 @@ if (MSVC)
   set(CMAKE_CUDA_FLAGS
     "${CMAKE_CUDA_FLAGS} -Xcompiler=\"/WX\" -rdc=true")
   set(CMAKE_CUDA_FLAGS_RELEASE
-    "${CMAKE_CUDA_FLAGS_RELEASE} /O2")
+    "${CMAKE_CUDA_FLAGS_RELEASE} -O3 -Xcompiler=\"/O2\"")
 else()
   set(CMAKE_CUDA_FLAGS
     "${CMAKE_CUDA_FLAGS} -Xcompiler=\"-Wall -Wextra -Wconversion -Wshadow\" -O3 -rdc=true")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ foreach(test ${TESTS})
   target_include_directories(${test} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
   # Ensure the main jitify header can be found.
   target_include_directories(${test} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-  target_link_libraries(${test} cuda gtest_main)
+  target_link_libraries(${test} gtest_main)
   set_property(TARGET ${test} PROPERTY CUDA_ARCHITECTURES OFF)
   if (NOT WIN32)
     target_link_libraries(${test} ${CMAKE_DL_LIBS})

--- a/jitify2.hpp
+++ b/jitify2.hpp
@@ -5655,7 +5655,7 @@ inline bool make_directory(const char* path,
   bool is_dir;
   if (path_exists(path, &is_dir)) return is_dir;
 #if defined _WIN32 || defined _WIN64
-  return ::mkdir(path) == 0 || errno == EEXIST;
+  return ::_mkdir(path) == 0 || errno == EEXIST;
 #else
   return ::mkdir(path, mode) == 0 || errno == EEXIST;
 #endif

--- a/jitify2.hpp
+++ b/jitify2.hpp
@@ -5500,9 +5500,21 @@ class NewFile {
   std::string error_ = "Success";
 
   std::string get_error_msg(bool success, const std::string& operation) const {
+    char error_buf[256];
+    const char* error_str = error_buf;
+#if defined _WIN32 || defined _WIN64
+    ::strerror_s(error_buf, sizeof(error_buf), errno);
+#else
+    // See here for why this is necessary:
+    // http://www.club.cc.cmu.edu/~cmccabe/blog_strerror.html
+#if !((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && !_GNU_SOURCE)
+    error_str =
+#endif
+        ::strerror_r(errno, error_buf, sizeof(error_buf));
+#endif
     return success ? "Success"
                    : "Failed to " + operation + " " + filename_ + ": (" +
-                         std::to_string(errno) + ") " + ::strerror(errno);
+                         std::to_string(errno) + ") " + error_str;
   }
 
  public:

--- a/jitify2.hpp
+++ b/jitify2.hpp
@@ -6315,7 +6315,7 @@ class ProgramCache {
                             StringVec extra_linker_options = {}) {
     // Add the current CUDA context to the key, as modules are context-specific.
     CUcontext context;
-    if (!cuda) return LoadedProgram::Error(cuda().error());
+    if (!cuda()) return LoadedProgram::Error(cuda().error());
     CUresult cuda_ret = cuda().CtxGetCurrent()(&context);
     if (cuda_ret != CUDA_SUCCESS) {
       return LoadedProgram::Error(detail::get_cuda_error_string(cuda_ret));

--- a/jitify2.hpp
+++ b/jitify2.hpp
@@ -72,6 +72,11 @@
 #define JITIFY_LINK_NVRTC_STATIC 0
 #endif
 
+// Default to using dynamic linking of CUDA.
+#ifndef JITIFY_LINK_CUDA_STATIC
+#define JITIFY_LINK_CUDA_STATIC 0
+#endif
+
 // Users can enable this for easier debugging.
 #ifndef JITIFY_FAIL_IMMEDIATELY
 #define JITIFY_FAIL_IMMEDIATELY 0
@@ -174,14 +179,14 @@
 #define JITIFY_THROW_OR_RETURN(msg) return msg
 #endif
 
-#define JITIFY_THROW_OR_RETURN_IF_CUDA_ERROR(call) \
-  do {                                             \
-    CUresult jitify_cuda_ret = call;               \
-    if (jitify_cuda_ret != CUDA_SUCCESS) {         \
-      const char* error_c;                         \
-      cuGetErrorString(jitify_cuda_ret, &error_c); \
-      JITIFY_THROW_OR_RETURN(error_c);             \
-    }                                              \
+#define JITIFY_THROW_OR_RETURN_IF_CUDA_ERROR(call)        \
+  do {                                                    \
+    CUresult jitify_cuda_ret = call;                      \
+    if (jitify_cuda_ret != CUDA_SUCCESS) {                \
+      const char* error_c;                                \
+      cuda().GetErrorString()(jitify_cuda_ret, &error_c); \
+      JITIFY_THROW_OR_RETURN(error_c);                    \
+    }                                                     \
   } while (0)
 
 #endif  // not JITIFY_SERIALIZATION_ONLY
@@ -963,12 +968,6 @@ inline uint64_t fasthash64(uint64_t h) {
   return h;
 }
 
-inline std::string get_cuda_error_string(CUresult ret) {
-  const char* error_c;
-  cuGetErrorString(ret, &error_c);
-  return "CUDA error " + std::to_string(ret) + ": " + error_c;
-}
-
 // Returns the sha256 digest as a string of 32 hex digits.
 inline std::string sha256(const char* data, size_t size) {
   // This implementation is based on pseudocode from Wikipedia.
@@ -1079,13 +1078,218 @@ inline std::string normalize_cuda_symbol_name(const std::string& symbol_name) {
   return std::regex_replace(symbol_name, re_anonymous_namespace, "<unnamed>");
 }
 
+template <typename ResultType, typename... Args>
+using function_type = ResultType(Args...);
+
+template <typename ResultType, typename... Args>
+class SafeFunction {
+ public:
+  SafeFunction(std::function<ResultType(Args...)> func, std::string name)
+      : func_(func), name_(std::move(name)) {}
+
+  explicit operator bool() const { return static_cast<bool>(func_); }
+
+  ResultType operator()(Args... args) const {
+    if (!func_) {
+      JITIFY_THROW_OR_TERMINATE("Failed to find dynamic symbol " + name_);
+    }
+    return func_(args...);
+  }
+
+ private:
+  std::function<ResultType(Args...)> func_;
+  std::string name_;
+};
+
+#if !JITIFY_LINK_NVRTC_STATIC || !JITIFY_LINK_CUDA_STATIC
+class DynamicLibrary {
+  using handle_type =
+#if defined(_WIN32) || defined(_WIN64)
+      HMODULE;
+#else
+      void*;
+#endif
+
+ private:
+  struct Deleter {
+    void operator()(handle_type handle) const {
+      if (handle) {
+#if defined(_WIN32) || defined(_WIN64)
+        ::FreeLibrary(handle);
+#else
+        ::dlclose(handle);
+#endif
+      }
+    }
+  };
+
+  std::unique_ptr<std::remove_pointer<handle_type>::type, Deleter> lib_;
+  std::string error_;
+
+ public:
+  DynamicLibrary() = default;
+  DynamicLibrary(const char* name) { open(name); }
+
+  bool open(const char* name) {
+    error_.clear();
+#if defined(_WIN32) || defined(_WIN64)
+    lib_.reset(::LoadLibraryA(name));
+    if (!lib_) {
+      DWORD error_code = ::GetLastError();
+      LPSTR buffer = nullptr;
+      size_t size = ::FormatMessageA(
+          FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+              FORMAT_MESSAGE_IGNORE_INSERTS,
+          NULL, error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+          (LPSTR)&buffer, 0, NULL);
+      error_ = std::string(buffer, size);
+      ::LocalFree(buffer);
+      return false;
+    }
+#else
+    ::dlerror();  // Clear any existing error
+    lib_.reset(::dlopen(name, RTLD_LAZY));
+    if (!lib_) {
+      error_ = ::dlerror();
+      return false;
+    }
+#endif
+    return true;
+  }
+
+  void close() { lib_.reset(); }
+
+  explicit operator bool() const { return static_cast<bool>(lib_); }
+  const std::string& error() const { return error_; }
+
+  template <typename ResultType, typename... Args>
+  SafeFunction<ResultType, Args...> function(const char* func_name) const {
+    auto* func =
+#if defined(_WIN32) || defined(_WIN64)
+        ::GetProcAddress(lib_.get(), func_name);
+#else
+        ::dlsym(lib_.get(), func_name);
+#endif
+    return SafeFunction<ResultType, Args...>(
+        reinterpret_cast<function_type<ResultType, Args...>*>(func), func_name);
+  }
+};
+#endif  // !JITIFY_LINK_NVRTC_STATIC || !JITIFY_LINK_CUDA_STATIC
+
 }  // namespace detail
 
-// class LoadedProgramData;
+class LibCuda
+#if !JITIFY_LINK_CUDA_STATIC
+    : public detail::DynamicLibrary
+#endif
+{
+ public:
+  LibCuda() {
+#if !JITIFY_LINK_CUDA_STATIC
+    std::string libname =
+#if defined(_WIN32) || defined(_WIN64)
+        "nvcuda.dll";
+#else
+        "libcuda.so";
+#endif
+    this->open(libname.c_str());
+#endif  // !JITIFY_LINK_CUDA_STATIC
+  }
+
+#define JITIFY_STR_IMPL(x) #x
+#define JITIFY_STR(x) JITIFY_STR_IMPL(x)
+#if JITIFY_LINK_CUDA_STATIC
+  operator bool() { return true; }
+  const std::string& error() const {
+    static std::string err;
+    return err;
+  }
+#define JITIFY_DEFINE_CUDA_WRAPPER(name, result_type, ...)        \
+  detail::function_type<result_type, __VA_ARGS__>* name() const { \
+    return &cu##name;                                             \
+  }
+#else  // dynamic linking
+#define JITIFY_DEFINE_CUDA_WRAPPER(name, result_type, ...)              \
+  detail::SafeFunction<result_type, __VA_ARGS__> name() const {         \
+    static const auto func =                                            \
+        this->function<result_type, __VA_ARGS__>(JITIFY_STR(cu##name)); \
+    return func;                                                        \
+  }
+#endif
+  JITIFY_DEFINE_CUDA_WRAPPER(DriverGetVersion, CUresult, int*)
+  JITIFY_DEFINE_CUDA_WRAPPER(GetErrorString, CUresult, CUresult, const char**)
+  JITIFY_DEFINE_CUDA_WRAPPER(GetErrorName, CUresult, CUresult, const char**)
+  JITIFY_DEFINE_CUDA_WRAPPER(CtxGetCurrent, CUresult, CUcontext*)
+  JITIFY_DEFINE_CUDA_WRAPPER(CtxGetDevice, CUresult, CUdevice*)
+  JITIFY_DEFINE_CUDA_WRAPPER(DeviceGet, CUresult, CUdevice*, int)
+  JITIFY_DEFINE_CUDA_WRAPPER(DeviceGetAttribute, CUresult, int*,
+                             CUdevice_attribute, CUdevice)
+  JITIFY_DEFINE_CUDA_WRAPPER(LinkCreate, CUresult, unsigned int, CUjit_option*,
+                             void**, CUlinkState*)
+  JITIFY_DEFINE_CUDA_WRAPPER(LinkDestroy, CUresult, CUlinkState)
+  JITIFY_DEFINE_CUDA_WRAPPER(LinkAddData, CUresult, CUlinkState, CUjitInputType,
+                             void*, size_t, const char*, unsigned int,
+                             CUjit_option*, void**)
+  JITIFY_DEFINE_CUDA_WRAPPER(LinkAddFile, CUresult, CUlinkState, CUjitInputType,
+                             const char*, unsigned int, CUjit_option*, void**)
+  JITIFY_DEFINE_CUDA_WRAPPER(LinkComplete, CUresult, CUlinkState, void**,
+                             size_t*)
+  JITIFY_DEFINE_CUDA_WRAPPER(ModuleLoadData, CUresult, CUmodule*, const void*)
+  JITIFY_DEFINE_CUDA_WRAPPER(ModuleUnload, CUresult, CUmodule)
+  JITIFY_DEFINE_CUDA_WRAPPER(ModuleGetFunction, CUresult, CUfunction*, CUmodule,
+                             const char*)
+  JITIFY_DEFINE_CUDA_WRAPPER(ModuleGetGlobal, CUresult, CUdeviceptr*, size_t*,
+                             CUmodule, const char*)
+  JITIFY_DEFINE_CUDA_WRAPPER(MemcpyHtoDAsync, CUresult, CUdeviceptr,
+                             const void*, size_t, CUstream)
+  JITIFY_DEFINE_CUDA_WRAPPER(MemcpyDtoHAsync, CUresult, void*, CUdeviceptr,
+                             size_t, CUstream)
+  JITIFY_DEFINE_CUDA_WRAPPER(FuncGetAttribute, CUresult, int*,
+                             CUfunction_attribute, CUfunction)
+  JITIFY_DEFINE_CUDA_WRAPPER(FuncSetAttribute, CUresult, CUfunction,
+                             CUfunction_attribute, int)
+  JITIFY_DEFINE_CUDA_WRAPPER(OccupancyMaxPotentialBlockSizeWithFlags, CUresult,
+                             int*, int*, CUfunction, CUoccupancyB2DSize, size_t,
+                             int, unsigned int)
+  JITIFY_DEFINE_CUDA_WRAPPER(LaunchKernel, CUresult, CUfunction, unsigned int,
+                             unsigned int, unsigned int, unsigned int,
+                             unsigned int, unsigned int, unsigned int, CUstream,
+                             void**, void**)
+#undef JITIFY_DEFINE_CUDA_WRAPPER
+#undef JITIFY_STR
+#undef JITIFY_STR_IMPL
+
+  // Returns the runtime CUDA version in the same format as CUDA_VERSION (e.g.,
+  // 11040 for 11.4).
+  int get_version() const {
+    static const int version = [this] {
+      int result;
+      DriverGetVersion()(&result);
+      return result;
+    }();
+    return version;
+  }
+};
+
+inline LibCuda& cuda() {
+  static LibCuda lib;
+  return lib;
+}
+
+namespace detail {
+
+inline std::string get_cuda_error_string(CUresult ret) {
+  const char* error_c;
+  cuda().GetErrorString()(ret, &error_c);
+  return "CUDA error " + std::to_string(ret) + ": " + error_c;
+}
+
+}  // namespace detail
+
 class Kernel;
 
 struct CudaModuleDestructor {
-  void operator()(CUmodule module) const { cuModuleUnload(module); }
+  void operator()(CUmodule module) const { cuda().ModuleUnload()(module); }
 };
 using UniqueCudaModule =
     std::unique_ptr<std::remove_pointer<CUmodule>::type, CudaModuleDestructor>;
@@ -1156,7 +1360,7 @@ class LoadedProgramData {
       symbol_name = iter->second;  // Replace name with lowered name.
     }
     JITIFY_THROW_OR_RETURN_IF_CUDA_ERROR(
-        cuModuleGetGlobal(ptr, size, module(), symbol_name.c_str()));
+        cuda().ModuleGetGlobal()(ptr, size, module(), symbol_name.c_str()));
     return {};
   }
 
@@ -1177,7 +1381,7 @@ class LoadedProgramData {
         get_global_ptr_with_size(std::move(name), size_bytes, &ptr);
     if (!error.empty()) return error;
     JITIFY_THROW_OR_RETURN_IF_CUDA_ERROR(
-        cuMemcpyDtoHAsync(data, ptr, size_bytes, stream));
+        cuda().MemcpyDtoHAsync()(data, ptr, size_bytes, stream));
     return {};
   }
 
@@ -1201,7 +1405,7 @@ class LoadedProgramData {
         get_global_ptr_with_size(std::move(name), size_bytes, &ptr);
     if (!error.empty()) return error;
     JITIFY_THROW_OR_RETURN_IF_CUDA_ERROR(
-        cuMemcpyHtoDAsync(ptr, data, size_bytes, stream));
+        cuda().MemcpyHtoDAsync()(ptr, data, size_bytes, stream));
     return {};
   }
 
@@ -1283,7 +1487,7 @@ class KernelData {
    */
   ErrorMsg set_attribute(CUfunction_attribute attribute, int value) const {
     JITIFY_THROW_OR_RETURN_IF_CUDA_ERROR(
-        cuFuncSetAttribute(function_, attribute, value));
+        cuda().FuncSetAttribute()(function_, attribute, value));
     return {};
   }
 
@@ -1294,7 +1498,7 @@ class KernelData {
    */
   ErrorMsg get_attribute(CUfunction_attribute attribute, int* value) const {
     JITIFY_THROW_OR_RETURN_IF_CUDA_ERROR(
-        cuFuncGetAttribute(value, attribute, function_));
+        cuda().FuncGetAttribute()(value, attribute, function_));
     return {};
   }
 
@@ -1351,7 +1555,8 @@ inline Kernel Kernel::get_kernel(LoadedProgramData program, std::string name) {
     name = iter->second;  // Replace name with lowered name.
   }
   CUfunction function;
-  CUresult ret = cuModuleGetFunction(&function, program.module(), name.c_str());
+  CUresult ret =
+      cuda().ModuleGetFunction()(&function, program.module(), name.c_str());
   if (ret != CUDA_SUCCESS) {
     return Error("get_kernel with name=\"" + name +
                  "\" failed: " + detail::get_cuda_error_string(ret));
@@ -1401,8 +1606,7 @@ class ConfiguredKernelData {
    *  \return An empty string on success, otherwise an error message.
    */
   ErrorMsg launch(void** arg_ptrs) const {
-    JITIFY_THROW_OR_RETURN_IF_CUDA_ERROR(cuLaunchKernel(
-        // function_, grid_.x, grid_.y, grid_.z, block_.x, block_.y, block_.z,
+    JITIFY_THROW_OR_RETURN_IF_CUDA_ERROR(cuda().LaunchKernel()(
         kernel_.function(), grid_.x, grid_.y, grid_.z, block_.x, block_.y,
         block_.z, shared_memory_bytes_, stream_, arg_ptrs, nullptr));
     return {};
@@ -1475,7 +1679,7 @@ inline ConfiguredKernel ConfiguredKernel::configure_1d_max_occupancy(
     CUoccupancyB2DSize shared_memory_bytes_callback, CUstream stream,
     unsigned int flags) {
   int grid, block;
-  CUresult ret = cuOccupancyMaxPotentialBlockSizeWithFlags(
+  CUresult ret = cuda().OccupancyMaxPotentialBlockSizeWithFlags()(
       &grid, &block, kernel.function(), shared_memory_bytes_callback,
       shared_memory_bytes, max_block_size, flags);
   if (ret != CUDA_SUCCESS) {
@@ -1503,7 +1707,7 @@ class LoadedProgram
 inline LoadedProgram LoadedProgram::load(StringRef cubin,
                                          StringMap lowered_name_map) {
   CUmodule module;
-  CUresult ret = cuModuleLoadData(&module, cubin.data());
+  CUresult ret = cuda().ModuleLoadData()(&module, cubin.data());
   if (ret != CUDA_SUCCESS) {
     return Error("Loading failed: " + detail::get_cuda_error_string(ret));
   }
@@ -1849,18 +2053,18 @@ inline bool link_programs(size_t num_programs, const std::string* programs[],
   };
 
   CUlinkState culink_state;
-  JITIFY_CHECK_CULINK(cuLinkCreate((unsigned)option_keys.size(),
-                                   option_keys.data(), option_vals.data(),
-                                   &culink_state));
+  JITIFY_CHECK_CULINK(cuda().LinkCreate()((unsigned)option_keys.size(),
+                                          option_keys.data(),
+                                          option_vals.data(), &culink_state));
   struct ScopedCULinkStateDestroyer {
     CUlinkState& culink_state_;
     ScopedCULinkStateDestroyer(CUlinkState& culink_state)
         : culink_state_(culink_state) {}
-    ~ScopedCULinkStateDestroyer() { cuLinkDestroy(culink_state_); }
+    ~ScopedCULinkStateDestroyer() { cuda().LinkDestroy()(culink_state_); }
   } culink_state_scope_guard{culink_state};
 
   for (size_t i = 0; i < num_programs; ++i) {
-    JITIFY_CHECK_CULINK(cuLinkAddData(
+    JITIFY_CHECK_CULINK(cuda().LinkAddData()(
         culink_state, program_types[i], (void*)programs[i]->data(),
         programs[i]->size(), "jitified_source", 0, 0, 0));
   }
@@ -1875,14 +2079,14 @@ inline bool link_programs(size_t num_programs, const std::string* programs[],
       // Infer based on filename.
       jit_input_type = get_cuda_jit_input_type(&link_file);
     }
-    CUresult result =
-        cuLinkAddFile(culink_state, jit_input_type, link_file.c_str(), 0, 0, 0);
+    CUresult result = cuda().LinkAddFile()(culink_state, jit_input_type,
+                                           link_file.c_str(), 0, 0, 0);
     int path_num = 0;
     while (result == CUDA_ERROR_FILE_NOT_FOUND &&
            path_num < (int)link_paths.size()) {
       std::string filename = path_join(link_paths[path_num++], link_file);
-      result = cuLinkAddFile(culink_state, jit_input_type, filename.c_str(), 0,
-                             0, 0);
+      result = cuda().LinkAddFile()(culink_state, jit_input_type,
+                                    filename.c_str(), 0, 0, 0);
     }
     if (log) {
       if (result == CUDA_ERROR_FILE_NOT_FOUND) {
@@ -1898,7 +2102,8 @@ inline bool link_programs(size_t num_programs, const std::string* programs[],
 
   size_t cubin_size;
   void* cubin_ptr;
-  JITIFY_CHECK_CULINK(cuLinkComplete(culink_state, &cubin_ptr, &cubin_size));
+  JITIFY_CHECK_CULINK(
+      cuda().LinkComplete()(culink_state, &cubin_ptr, &cubin_size));
   set_log();
   if (linked_cubin) {
     linked_cubin->assign((char*)cubin_ptr, (char*)cubin_ptr + cubin_size);
@@ -2034,9 +2239,7 @@ inline LinkedProgram LinkedProgram::link(
   program_types.reserve(num_programs);
   for (size_t i = 0; i < num_programs; ++i) {
     const CompiledProgramData& compiled_program = *compiled_programs[i];
-    int cuda_driver_version;
-    cuDriverGetVersion(&cuda_driver_version);
-    if (std::min(CUDA_VERSION, cuda_driver_version) < 11040 &&
+    if (std::min(CUDA_VERSION, cuda().get_version()) < 11040 &&
         !compiled_program.nvvm().empty()) {
       return Error("Linking NVVM IR is not supported with CUDA < 11.4");
     }
@@ -2095,87 +2298,6 @@ inline LinkedProgram LinkedProgram::link_impl(
                        std::move(log), std::move(options));
 }
 
-namespace detail {
-
-template <typename ResultType, typename... Args>
-using function_type = ResultType(Args...);
-
-#if !JITIFY_LINK_NVRTC_STATIC
-class DynamicLibrary {
-  using handle_type =
-#if defined(_WIN32) || defined(_WIN64)
-      HMODULE;
-#else
-      void*;
-#endif
-
- private:
-  struct Deleter {
-    void operator()(handle_type handle) const {
-      if (handle) {
-#if defined(_WIN32) || defined(_WIN64)
-        ::FreeLibrary(handle);
-#else
-        ::dlclose(handle);
-#endif
-      }
-    }
-  };
-
-  std::unique_ptr<std::remove_pointer<handle_type>::type, Deleter> lib_;
-  std::string error_;
-
- public:
-  DynamicLibrary() = default;
-  DynamicLibrary(const char* name) { open(name); }
-
-  bool open(const char* name) {
-    error_.clear();
-#if defined(_WIN32) || defined(_WIN64)
-    lib_.reset(::LoadLibraryA(name));
-    if (!lib_) {
-      DWORD error_code = ::GetLastError();
-      LPSTR buffer = nullptr;
-      size_t size = ::FormatMessageA(
-          FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
-              FORMAT_MESSAGE_IGNORE_INSERTS,
-          NULL, error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-          (LPSTR)&buffer, 0, NULL);
-      error_ = std::string(buffer, size);
-      ::LocalFree(buffer);
-      return false;
-    }
-#else
-    ::dlerror();  // Clear any existing error
-    lib_.reset(::dlopen(name, RTLD_LAZY));
-    if (!lib_) {
-      error_ = ::dlerror();
-      return false;
-    }
-#endif
-    return true;
-  }
-
-  void close() { lib_.reset(); }
-
-  explicit operator bool() const { return static_cast<bool>(lib_); }
-  const std::string& error() const { return error_; }
-
-  template <typename ResultType, typename... Args>
-  function_type<ResultType, Args...>* function(const char* func_name) const {
-    auto* func =
-#if defined(_WIN32) || defined(_WIN64)
-        ::GetProcAddress(lib_.get(), func_name);
-#else
-        ::dlsym(lib_.get(), func_name);
-#endif
-    return reinterpret_cast<function_type<ResultType, Args...>*>(func);
-  }
-};
-#endif  // !JITIFY_LINK_NVRTC_STATIC
-
-}  // namespace detail
-
 class LibNvrtc
 #if !JITIFY_LINK_NVRTC_STATIC
     : public detail::DynamicLibrary
@@ -2208,6 +2330,8 @@ class LibNvrtc
 #endif  // !JITIFY_LINK_NVRTC_STATIC
   }
 
+#define JITIFY_STR_IMPL(x) #x
+#define JITIFY_STR(x) JITIFY_STR_IMPL(x)
 #if JITIFY_LINK_NVRTC_STATIC
   operator bool() { return true; }
   const std::string& error() const {
@@ -2219,11 +2343,11 @@ class LibNvrtc
     return &nvrtc##name;                                          \
   }
 #else  // dynamic linking
-#define JITIFY_DEFINE_NVRTC_WRAPPER(name, result_type, ...)       \
-  detail::function_type<result_type, __VA_ARGS__>* name() const { \
-    static const auto func =                                      \
-        this->function<result_type, __VA_ARGS__>("nvrtc" #name);  \
-    return func;                                                  \
+#define JITIFY_DEFINE_NVRTC_WRAPPER(name, result_type, ...)                \
+  detail::SafeFunction<result_type, __VA_ARGS__> name() const {            \
+    static const auto func =                                               \
+        this->function<result_type, __VA_ARGS__>(JITIFY_STR(nvrtc##name)); \
+    return func;                                                           \
   }
 #endif
   JITIFY_DEFINE_NVRTC_WRAPPER(AddNameExpression, nvrtcResult, nvrtcProgram,
@@ -2278,6 +2402,8 @@ class LibNvrtc
                               size_t*)
   JITIFY_DEFINE_NVRTC_WRAPPER(Version, nvrtcResult, int*, int*)
 #undef JITIFY_DEFINE_NVRTC_WRAPPER
+#undef JITIFY_STR_IMPL
+#undef JITIFY_STR
 
   // Returns the runtime NVRTC version the same format as CUDA_VERSION.
   int get_version() const {
@@ -2372,11 +2498,11 @@ inline int get_current_device_compute_capability(std::string* error = nullptr) {
   CUdevice device;
   int cc_major, cc_minor;
   CUresult ret;
-  if ((ret = cuCtxGetDevice(&device)) != CUDA_SUCCESS ||
-      (ret = cuDeviceGetAttribute(
+  if ((ret = cuda().CtxGetDevice()(&device)) != CUDA_SUCCESS ||
+      (ret = cuda().DeviceGetAttribute()(
            &cc_major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device)) !=
           CUDA_SUCCESS ||
-      (ret = cuDeviceGetAttribute(
+      (ret = cuda().DeviceGetAttribute()(
            &cc_minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, device)) !=
           CUDA_SUCCESS) {
     if (error) *error = get_cuda_error_string(ret);
@@ -2416,7 +2542,7 @@ inline int limit_to_supported_compute_capability(int cc,
     cc = std::min(cc, max_supported_arch);
   } else {
     // Ensure that future CUDA versions just work (even if suboptimal).
-    const int cuda_major = std::min(11, CUDA_VERSION / 1000);
+    const int cuda_major = std::min(11, cuda().get_version() / 1000);
     // clang-format off
     switch (cuda_major) {
       case 11: cc = std::min(cc, 80); break; // Ampere
@@ -6152,7 +6278,7 @@ class ProgramCache {
                             StringVec extra_linker_options = {}) {
     // Add the current CUDA context to the key, as modules are context-specific.
     CUcontext context;
-    CUresult cuda_ret = cuCtxGetCurrent(&context);
+    CUresult cuda_ret = cuda().CtxGetCurrent()(&context);
     if (cuda_ret != CUDA_SUCCESS) {
       return LoadedProgram::Error(detail::get_cuda_error_string(cuda_ret));
     }

--- a/jitify2.hpp
+++ b/jitify2.hpp
@@ -1860,7 +1860,7 @@ inline std::string path_base(const std::string& p) {
 inline std::string path_join(StringRef p1, StringRef p2) {
 #if defined _WIN32 || defined _WIN64
   // Note that Windows supports both forward and backslash path separators.
-  const char* sep = "\\/";
+  const char* sep = "/\\";
 #else
   const char* sep = "/";
 #endif

--- a/jitify2_test.cu
+++ b/jitify2_test.cu
@@ -601,7 +601,7 @@ TEST(Jitify2Test, PathJoin) {
   EXPECT_EQ(jitify2::detail::path_join("foo/bar/", "2/1"), "foo/bar/2/1");
   EXPECT_EQ(jitify2::detail::path_join("foo/bar", "/2/1"), "");
 #if defined _WIN32 || defined _WIN64
-  EXPECT_EQ(jitify2::detail::path_join("foo\\bar", "2\\1"), "foo\\bar\\2\\1");
+  EXPECT_EQ(jitify2::detail::path_join("foo\\bar", "2\\1"), "foo\\bar/2\\1");
   EXPECT_EQ(jitify2::detail::path_join("foo\\bar\\", "2\\1"), "foo\\bar\\2\\1");
   EXPECT_EQ(jitify2::detail::path_join("foo\\bar", "\\2\\1"), "");
 #endif

--- a/jitify2_test.cu
+++ b/jitify2_test.cu
@@ -45,7 +45,7 @@
     CUresult status = call;                                               \
     if (status != CUDA_SUCCESS) {                                         \
       const char* str;                                                    \
-      cuGetErrorName(status, &str);                                       \
+      cuda().GetErrorName()(status, &str);                                \
       std::cout << "(CUDA) returned " << str;                             \
       std::cout << " (" << __FILE__ << ":" << __LINE__ << ":" << __func__ \
                 << "())" << std::endl;                                    \
@@ -281,8 +281,8 @@ __global__ void my_kernel(const T*, U*) {}
   for (int i = 0; i < nrep; ++i) {
     // Benchmark direct kernel launch.
     auto t0 = std::chrono::steady_clock::now();
-    cuLaunchKernel(kernel->function(), grid.x, grid.y, grid.z, block.x, block.y,
-                   block.z, 0, 0, arg_ptrs, nullptr);
+    cuda().LaunchKernel()(kernel->function(), grid.x, grid.y, grid.z, block.x,
+                          block.y, block.z, 0, 0, arg_ptrs, nullptr);
     auto dt = std::chrono::steady_clock::now() - t0;
     // Using the minimum is more robust than the average (though this test still
     // remains sensitive to the system environment and has been observed to fail
@@ -811,6 +811,7 @@ TEST(Jitify2Test, InvalidPrograms) {
   EXPECT_NE(get_error(Program("bad_program", "NOT CUDA C!")->preprocess()), "");
 }
 
+#if CUDA_VERSION >= 11040
 TEST(Jitify2Test, CompileLTO_NVVM) {
   static const char* const source = R"(
 const int arch = __CUDA_ARCH__ / 10;
@@ -828,6 +829,7 @@ const int arch = __CUDA_ARCH__ / 10;
   ASSERT_EQ(program->link()->load()->get_global_value("arch", &arch), "");
   EXPECT_EQ(arch, current_arch);
 }
+#endif  // CUDA_VERSION >= 11040
 
 TEST(Jitify2Test, LinkMultiplePrograms) {
   static const char* const source1 = R"(
@@ -868,6 +870,7 @@ __global__ void my_kernel(int* data) {
   CHECK_CUDART(cudaFree(d_data));
 }
 
+#if CUDA_VERSION >= 11040
 TEST(Jitify2Test, LinkLTO) {
   static const char* const source1 = R"(
 __constant__ int c = 5;
@@ -910,6 +913,7 @@ __global__ void my_kernel(int* data) {
   EXPECT_EQ(h_data, 26);
   CHECK_CUDART(cudaFree(d_data));
 }
+#endif  // CUDA_VERSION >= 11040
 
 TEST(Jitify2Test, LinkExternalFiles) {
   static const char* const source1 = R"(
@@ -1078,9 +1082,9 @@ __global__ void set_attribute_kernel(int* out, int* in) {
 
   // Query the maximum supported shared bytes per block.
   CUdevice device;
-  CHECK_CUDA(cuDeviceGet(&device, 0));
+  CHECK_CUDA(cuda().DeviceGet()(&device, 0));
   int shared_bytes;
-  CHECK_CUDA(cuDeviceGetAttribute(
+  CHECK_CUDA(cuda().DeviceGetAttribute()(
       &shared_bytes, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
       device));
 


### PR DESCRIPTION
- Adds support for runtime lazy-loading of the CUDA driver library, similar to the existing support for runtime-loading of the NVRTC library. This means that all dependencies on the CUDA Toolkit are now required only lazily at runtime.
- This is enabled by default, but can be disabled by defining `JITIFY_LINK_CUDA_STATIC=1` before including jitify2.hpp.
- This also adds two subtle changes that affect the NVRTC loading too:
  - Dynamically loaded symbols are wrapped in SafeFunction, which throws an error when called if the symbol was not found (instead of segfaulting).
  - Symbol names now match the compile-time symbols exactly, even if the API header (cuda.h or nvrtc.h) defines them indirectly via macros.
    E.g., cuda.h defines cuMemcpyHtoD to cuMemcpyHtoD_v2, and this is correctly handled by the new code.
- Note that a large chunk of this diff is just moving the existing dynamic library loading code to a higher point in the file.