### PR TITLE
Allow non-standard nvcc and fix gtest warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ CXX11 ?= 1
 
 CUDA_DIR ?= /usr/local/cuda
 CUDA_INC_DIR ?= $(CUDA_DIR)/include
+NVCC ?= ${CUDA_DIR}/bin/nvcc
 
 CXXFLAGS += -pthread
 
@@ -65,7 +66,7 @@ $(GTEST_STATIC_LIB):
 	git clone https://github.com/google/googletest.git $(GTEST_DIR)
 	cd $(GTEST_DIR) && git checkout release-1.8.1 && rm -rf build && mkdir build && cd build && cmake .. && make -j8
 
-GTEST_INC = -I$(GTEST_DIR)/googletest/include
+GTEST_INC = -isystem $(GTEST_DIR)/googletest/include
 GTEST_LIB = -L$(GTEST_DIR)/build/googlemock/gtest -lgtest -lgtest_main
 
 CUB_DIR ?= /tmp/cub
@@ -82,7 +83,7 @@ jitify_test: jitify_test.cu $(HEADERS) $(GTEST_STATIC_LIB) $(CUB_HEADER) Makefil
 	# Link a 2nd compilation unit to ensure no multiple definition errors.
 	echo "#include \"jitify.hpp\"\n#include \"example_headers/my_header1.cuh.jit\"" \
         > jitify_2nd_compilation_unit.cpp
-	nvcc -o $@ $< jitify_2nd_compilation_unit.cpp -rdc=true -std=c++11 -O3 \
+	$(NVCC) -o $@ $< jitify_2nd_compilation_unit.cpp -rdc=true -std=c++11 -O3 \
         -Xcompiler "$(CXXFLAGS) $(NVCC_EMBED) -pthread" \
         $(JITIFY_TEST_DEFINES) $(INC) $(GTEST_INC) $(CUB_INC) $(LIB) $(GTEST_LIB)
 


### PR DESCRIPTION
* Gtest headers should be included with -isystem (fixes any compiler warnings outwith our control)
* Introduce `NVCC` variable in makefile to use an arbitrary compiler