### PR TITLE
Feature/type traits climits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ HEADERS = jitify.hpp \
           example_headers/my_header1.cuh.jit \
           example_headers/my_header2.cuh
 
-all: jitify_example
+all: jitify_example jitify_test
 
 JITIFY_EXAMPLE_DEFINES = -DCUDA_INC_DIR="\"$(CUDA_INC_DIR)\""
 

--- a/jitify.hpp
+++ b/jitify.hpp
@@ -1438,7 +1438,7 @@ static const char* jitsafe_header_limits_h = R"(
 #if defined _WIN32 || defined _WIN64
  #define __WORDSIZE 32
 #else
- #if defined __x86_64__ && !defined __ILP32__
+ #if defined(__LP64__) || (defined __x86_64__ && !defined __ILP32__)
   #define __WORDSIZE 64
  #else
   #define __WORDSIZE 32
@@ -1454,26 +1454,26 @@ enum {
   CHAR_MIN = _JITIFY_CHAR_IS_UNSIGNED ? 0 : SCHAR_MIN,
   CHAR_MAX = _JITIFY_CHAR_IS_UNSIGNED ? UCHAR_MAX : SCHAR_MAX,
 };
-#define SHRT_MIN    (-32768)
-#define SHRT_MAX    32767
-#define USHRT_MAX   65535
+#define SHRT_MIN    (-SHRT_MAX - 1)
+#define SHRT_MAX    0x7fff
+#define USHRT_MAX   0xffff
 #define INT_MIN     (-INT_MAX - 1)
-#define INT_MAX     2147483647
-#define UINT_MAX    4294967295U
+#define INT_MAX     0x7fffffff
+#define UINT_MAX    0xffffffff
 #if __WORDSIZE == 64
- # define LONG_MAX  9223372036854775807L
+ # define LONG_MAX  LLONG_MAX
 #else
- # define LONG_MAX  2147483647L
+ # define LONG_MAX  UINT_MAX
 #endif
-#define LONG_MIN    (-LONG_MAX - 1L)
+#define LONG_MIN    (-LONG_MAX - 1)
 #if __WORDSIZE == 64
- #define ULONG_MAX  18446744073709551615UL
+ #define ULONG_MAX  ULLONG_MAX
 #else
- #define ULONG_MAX  4294967295UL
+ #define ULONG_MAX  UINT_MAX
 #endif
-#define LLONG_MAX  9223372036854775807LL
-#define LLONG_MIN  (-LLONG_MAX - 1LL)
-#define ULLONG_MAX 18446744073709551615ULL
+#define LLONG_MAX  0x7fffffffffffffff
+#define LLONG_MIN  (-LLONG_MAX - 1)
+#define ULLONG_MAX 0xffffffffffffffff
 )";
 
 static const char* jitsafe_header_iterator = R"(
@@ -1712,6 +1712,9 @@ static const char* jitsafe_header_type_traits = R"(
     template<> struct is_floating_point<float>       :  true_type {};
     template<> struct is_floating_point<double>      :  true_type {};
     template<> struct is_floating_point<long double> :  true_type {};
+    #if __cplusplus >= 201703L
+    template<typename T> inline constexpr bool is_floating_point_v = is_floating_point<T>::value;
+    #endif  // __cplusplus >= 201703L
 
     template<class T> struct is_integral              : false_type {};
     template<> struct is_integral<bool>               :  true_type {};
@@ -1726,6 +1729,9 @@ static const char* jitsafe_header_type_traits = R"(
     template<> struct is_integral<unsigned long>      :  true_type {};
     template<> struct is_integral<long long>          :  true_type {};
     template<> struct is_integral<unsigned long long> :  true_type {};
+    #if __cplusplus >= 201703L
+    template<typename T> inline constexpr bool is_integral_v = is_integral<T>::value;
+    #endif  // __cplusplus >= 201703L
 
     template<typename T> struct is_signed    : false_type {};
     template<> struct is_signed<float>       :  true_type {};
@@ -1746,6 +1752,9 @@ static const char* jitsafe_header_type_traits = R"(
 
     template<typename T, typename U> struct is_same      : false_type {};
     template<typename T>             struct is_same<T,T> :  true_type {};
+    #if __cplusplus >= 201703L
+    template<typename T, typename U> inline constexpr bool is_same_v = is_same<T, U>::value;
+    #endif  // __cplusplus >= 201703L
 
     template<class T> struct is_array : false_type {};
     template<class T> struct is_array<T[]> : true_type {};
@@ -1762,6 +1771,21 @@ static const char* jitsafe_header_type_traits = R"(
     // TODO: This is a hack; a proper implem is quite complicated.
     typedef typename F::result_type type;
     };
+
+    template<class T> struct is_pointer                    : false_type {};
+    template<class T> struct is_pointer<T*>                : true_type {};
+    template<class T> struct is_pointer<T* const>          : true_type {};
+    template<class T> struct is_pointer<T* volatile>       : true_type {};
+    template<class T> struct is_pointer<T* const volatile> : true_type {};
+    #if __cplusplus >= 201703L
+    template< class T > inline constexpr bool is_pointer_v = is_pointer<T>::value;
+    #endif  // __cplusplus >= 201703L
+
+    template <class T> struct remove_pointer { typedef T type; };
+    template <class T> struct remove_pointer<T*> { typedef T type; };
+    template <class T> struct remove_pointer<T* const> { typedef T type; };
+    template <class T> struct remove_pointer<T* volatile> { typedef T type; };
+    template <class T> struct remove_pointer<T* const volatile> { typedef T type; };
 
     template <class T> struct remove_reference { typedef T type; };
     template <class T> struct remove_reference<T&> { typedef T type; };
@@ -1827,6 +1851,13 @@ static const char* jitsafe_header_type_traits = R"(
     constexpr value_type operator()() const noexcept { return value; }
     #endif
     };
+
+    template<typename T> struct is_arithmetic :
+    std::integral_constant<bool, std::is_integral<T>::value ||
+                                 std::is_floating_point<T>::value> {};
+    #if __cplusplus >= 201703L
+    template<typename T> inline constexpr bool is_arithmetic_v = is_arithmetic<T>::value;
+    #endif  // __cplusplus >= 201703L
 
     template<class T> struct is_lvalue_reference : false_type {};
     template<class T> struct is_lvalue_reference<T&> : true_type {};


### PR DESCRIPTION
This PR adds functionality needed for QUDA to Jitify.  Once merged into the v1 branch, it should propagated to v2 since this is also a critical PR for RAPIDS which uses the v2 branch.

* Extends the functionality of `type_traits` with 
   * `is_floating_point_v` (c++17)
   * `is_integral_v` (c++17)
   * `is_same_v` (c++17)
   * `is_pointer`, `is_pointer_v` (c++17)
   * `remove_pointer`
   * `is_arithmetic` and `is_arithmetic_v` (c++17)
* `make all` now builds `jitify_test` as well as `jitify_example`
* Fix: the presence of `__LP64__` should be checked for when deciding on word size
* Fix: align the definitions of the `climits` built in to match those in libcu++
* Add test `BuiltinNumericCudaStdLimitsHeader` which mimics `BuiltinNumericLimitsHeader` but uses libcu++