### PR TITLE
handle escape(double quote) character used in #pragma expression

### DIFF
--- a/jitify.hpp
+++ b/jitify.hpp
@@ -678,6 +678,8 @@ inline bool load_source(
       // TODO: Handle block comments (currently they cause a compilation error).
       size_t comment_start = line_after_pragma.find("//");
       std::string pragma_args = line_after_pragma.substr(0, comment_start);
+      // handle quote character used in #pragma expression
+      pragma_args = replace_token(pragma_args, "\"", "\\\"");
       std::string comment = comment_start != std::string::npos
                                 ? line_after_pragma.substr(comment_start)
                                 : "";


### PR DESCRIPTION
handle escape(double quote) character used in #pragma expression, like:
    #pragma clang diagnostic ignored "-Wc++11-extensions"
in https://github.com/NVIDIA/cub/blob/main/cub/util_debug.cuh#L283