### PR TITLE
link impl only check libcuda for nvvm() not empty

### DIFF
--- a/jitify2.hpp
+++ b/jitify2.hpp
@@ -2253,12 +2253,13 @@ inline LinkedProgram LinkedProgram::link(
   std::vector<CUjitInputType> program_types;
   programs.reserve(num_programs);
   program_types.reserve(num_programs);
-  if (!cuda()) return Error(cuda().error());
   for (size_t i = 0; i < num_programs; ++i) {
     const CompiledProgramData& compiled_program = *compiled_programs[i];
-    if (std::min(CUDA_VERSION, cuda().get_version()) < 11040 &&
-        !compiled_program.nvvm().empty()) {
-      return Error("Linking NVVM IR is not supported with CUDA < 11.4");
+    if (!compiled_program.nvvm().empty()) {
+      if (!cuda()) return Error(cuda().error());
+      if (std::min(CUDA_VERSION, cuda().get_version()) < 11040) {
+        return Error("Linking NVVM IR is not supported with CUDA < 11.4");
+      }
     }
     const std::string& program = !compiled_program.nvvm().empty()
                                      ? compiled_program.nvvm()


### PR DESCRIPTION
I want to run this code on cpu machine without cuda driver. it needn't to load libcuda when program without nvvm.