### PR TITLE
Add support for nvJitLink to jitify2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,11 +106,17 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/jitify_2nd_compilation_unit.cu
 enable_testing()
 set(TESTS
     jitify2_test
+    jitify2_test_static
 )
 foreach(test ${TESTS})
+  if (${test} MATCHES "_static$")
+    STRING(REGEX REPLACE "_static$" "" test_base ${test})
+  else()
+    set(test_base ${test})
+  endif()
   # Note that generated headers are listed as source files to force dependency.
   add_executable(
-      ${test} EXCLUDE_FROM_ALL ${test}.cu
+      ${test} EXCLUDE_FROM_ALL ${test_base}.cu
       ${CMAKE_CURRENT_BINARY_DIR}/jitify_2nd_compilation_unit.cu
       ${CMAKE_CURRENT_BINARY_DIR}/example_headers/my_header1.cuh.jit
       ${CMAKE_CURRENT_BINARY_DIR}/jitify2_test_kernels.cu.jit.hpp
@@ -121,6 +127,13 @@ foreach(test ${TESTS})
   target_include_directories(${test} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
   target_link_libraries(${test} gtest_main)
   set_property(TARGET ${test} PROPERTY CUDA_ARCHITECTURES OFF)
+  if (${test} MATCHES "_static$")
+    target_compile_definitions(${test}
+                               PUBLIC JITIFY_LINK_CUDA_STATIC=1
+                               PUBLIC JITIFY_LINK_NVRTC_STATIC=1
+                               PUBLIC JITIFY_LINK_NVJITLINK_STATIC=1)
+    target_link_libraries(${test} cuda nvrtc nvJitLink)
+  endif()
   if (NOT WIN32)
     target_link_libraries(${test} ${CMAKE_DL_LIBS})
   endif()

--- a/jitify2.hpp
+++ b/jitify2.hpp
@@ -2522,7 +2522,7 @@ inline bool link_programs(size_t num_programs, const std::string* programs[],
 #if CUDA_VERSION >= 12000
   bool use_culink = false;
 #endif
-  for (const std::string& flag : {"-use-culink", "--use-culink"}) {
+  for (const std::string flag : {"-use-culink", "--use-culink"}) {
     auto iter = options_map.find(flag);
     if (iter != options_map.end()) {
 #if CUDA_VERSION >= 12000

--- a/jitify2.hpp
+++ b/jitify2.hpp
@@ -2174,6 +2174,10 @@ inline bool link_programs_culink(size_t num_programs,
       option_vals.push_back((void*)(intptr_t)0);
       option_keys.push_back(CU_JIT_FMA);
       option_vals.push_back((void*)(intptr_t)1);
+    } else if (key == "-Xptxas" || key == "--ptxas-options") {
+      // Ignore.
+    } else if (key == "-Xnvvm" || key == "--nvvm-options") {
+      // Ignore.
 #endif
     } else {
       if (error) *error = "Unknown option: " + key;
@@ -3457,7 +3461,7 @@ inline bool ptx_remove_unused_globals(std::string* ptx) {
 }
 
 // Returns false if there is a syntax error in the options.
-inline bool copy_compiler_option_for_driver_ptxas(
+inline bool copy_compiler_option_for_linker_ptxas(
     const StringVec& compiler_options, StringVec* linker_options,
     bool has_value, StringRef short_key, StringRef long_key,
     StringRef output_key = {}) {
@@ -3540,16 +3544,36 @@ inline CompiledProgram CompiledProgram::compile(
   // the linker does ptx->cubin compilation prior to linking. This allows users
   // to specify these options in compiler_options without having to worry about
   // whether they also need to be passed in linker_options.
-  detail::copy_compiler_option_for_driver_ptxas(
-      compiler_options, &linker_options, /*has_value = */ false, "-G",
+  detail::copy_compiler_option_for_linker_ptxas(
+      compiler_options, &linker_options, /*has_value=*/false, "-G",
       "--device-debug");
-  detail::copy_compiler_option_for_driver_ptxas(
-      compiler_options, &linker_options, /*has_value = */ false, "-lineinfo",
+  detail::copy_compiler_option_for_linker_ptxas(
+      compiler_options, &linker_options, /*has_value=*/false, "-lineinfo",
       "--generate-line-info",
       "--generate-line-info");  // Note that linker doesn't support "-lineinfo"
-  detail::copy_compiler_option_for_driver_ptxas(
-      compiler_options, &linker_options, /*has_value = */ true, "-maxrregcount",
+  detail::copy_compiler_option_for_linker_ptxas(
+      compiler_options, &linker_options, /*has_value=*/true, "-maxrregcount",
       "--maxrregcount");
+  detail::copy_compiler_option_for_linker_ptxas(
+      compiler_options, &linker_options, /*has_value=*/true, "-ftz",
+      "--ftz");
+  detail::copy_compiler_option_for_linker_ptxas(
+      compiler_options, &linker_options, /*has_value=*/true, "-prec-div",
+      "--prec-div");
+  detail::copy_compiler_option_for_linker_ptxas(
+      compiler_options, &linker_options, /*has_value=*/true, "-prec-sqrt",
+      "--prec-sqrt");
+  detail::copy_compiler_option_for_linker_ptxas(
+      compiler_options, &linker_options, /*has_value=*/true, "-fmad", "--fmad");
+  detail::copy_compiler_option_for_linker_ptxas(
+      compiler_options, &linker_options, /*has_value=*/true, "-use_fast_math",
+      "--use_fast_math");
+  detail::copy_compiler_option_for_linker_ptxas(
+      compiler_options, &linker_options, /*has_value=*/true, "-Xptxas",
+      "--ptxas-options");
+  detail::copy_compiler_option_for_linker_ptxas(
+      compiler_options, &linker_options, /*has_value=*/true, "-Xnvvm",
+      "--nvvm-options");
 
   return CompiledProgram(std::move(ptx), std::move(cubin), std::move(nvvm),
                          std::move(lowered_name_map), std::move(linker_options),

--- a/jitify2.hpp
+++ b/jitify2.hpp
@@ -2123,9 +2123,14 @@ inline bool link_programs_culink(size_t num_programs,
     } else if (/*key == "-lineinfo" ||*/ key == "--generate-line-info") {
       option_keys.push_back(CU_JIT_GENERATE_LINE_INFO);
       option_vals.push_back((void*)(intptr_t)1);
-    } else if (key == "-arch" || key == "--gpu-name") {
+    } else if (key == "-arch" || key == "--gpu-name" ||
+               key == "--gpu-architecture") {
       if (val.substr(0, 3) != "sm_") {
-        if (error) *error = "-arch/--gpu-name value must start with \"sm_\"";
+        if (error) {
+          *error =
+              "-arch/--gpu-name/--gpu-architecture value must start with "
+              "\"sm_\"";
+        }
         return false;
       }
       int arch = std::atoi(val.substr(3).c_str());
@@ -2304,9 +2309,14 @@ inline bool link_programs_nvjitlink(size_t num_programs,
       // HACK: Can't allow -lineinfo due to ambiguity with "-l<lib>".
     } else if (/*key == "-lineinfo" ||*/ key == "--generate-line-info") {
       options.push_back("-lineinfo");
-    } else if (key == "-arch" || key == "--gpu-name") {
+    } else if (key == "-arch" || key == "--gpu-name" ||
+               key == "--gpu-architecture") {
       if (val.substr(0, 3) != "sm_") {
-        if (error) *error = "-arch/--gpu-name value must start with \"sm_\"";
+        if (error) {
+          *error =
+              "-arch/--gpu-name/--gpu-architecture value must start with "
+              "\"sm_\"";
+        }
         return false;
       }
       options.push_back("-arch=" + val);

--- a/jitify2_test.cu
+++ b/jitify2_test.cu
@@ -960,8 +960,8 @@ __global__ void my_kernel(int* data) {
       linker_options.push_back("--use-culink");
     }
     Kernel kernel = Program("linktest_program2", source2)
-                      ->preprocess({"-rdc=true"}, linker_options)
-                      ->get_kernel("my_kernel");
+                        ->preprocess({"-rdc=true"}, linker_options)
+                        ->get_kernel("my_kernel");
     int* d_data;
     CHECK_CUDART(cudaMalloc((void**)&d_data, sizeof(int)));
     int h_data = 3;
@@ -1524,7 +1524,7 @@ __global__ void my_kernel(float* data) {
 #if CUDA_VERSION >= 11000
 TEST(Jitify2Test, LibCudaCxx) {
   // Test that each libcudacxx header can be compiled on its own.
-  for (const std::string& header :
+  for (const std::string header :
        {"atomic", "barrier", "cassert", "cfloat", "chrono", "climits",
         "cstddef", "cstdint", "ctime", "functional", "latch",
         /*"limits",*/ "ratio", "semaphore", "type_traits", "utility"}) {

--- a/jitify2_test.cu
+++ b/jitify2_test.cu
@@ -829,7 +829,7 @@ const int arch = __CUDA_ARCH__ / 10;
   EXPECT_EQ(program->nvvm().size(), program->lto_ir().size());
   int current_arch = get_current_device_arch();
   LinkedProgram linked_program = program->link();
-  if (CUDA_VERSION < 11040 || CUDA_VERSION >= 12000) {
+  if (CUDA_VERSION < 11040) {
     ASSERT_FALSE(linked_program.ok());
     ASSERT_TRUE(jitify2::detail::startswith(linked_program.error(),
                                             "Linking LTO IR is not supported"));
@@ -908,7 +908,7 @@ __global__ void my_kernel(int* data) {
   // TODO: Consider allowing refs not ptrs for programs, and also addding a
   //         get_kernel() shortcut method to LinkedProgram.
   LinkedProgram linked_program = LinkedProgram::link({&program1, &program2});
-  if (CUDA_VERSION < 11040 || CUDA_VERSION >= 12000) {
+  if (CUDA_VERSION < 11040) {
     ASSERT_FALSE(linked_program.ok());
     ASSERT_TRUE(jitify2::detail::startswith(linked_program.error(),
                                             "Linking LTO IR is not supported"));

--- a/jitify2_user_guide.md
+++ b/jitify2_user_guide.md
@@ -233,6 +233,18 @@ $ make check
   dynamic loading of the NVRTC dynamic library and allows the
   library to be linked statically.
 
+- `JITIFY_LINK_NVJITLINK_STATIC=0`
+
+  Defining this macro to 1 before including the jitify header disables
+  dynamic loading of the nvJitLink dynamic library and allows the
+  library to be linked statically.
+
+- `JITIFY_LINK_CUDA_STATIC=0`
+
+  Defining this macro to 1 before including the jitify header disables
+  dynamic loading of the CUDA dynamic library and allows the
+  library to be linked statically.
+
 - `JITIFY_FAIL_IMMEDIATELY=0`
 
   Defining this macro to 1 before including the jitify header causes
@@ -241,14 +253,22 @@ $ make check
   debugging, as it allows the origin of an error to be found via a
   backtrace.
 
+- `JITIFY_USE_LIBCUFILT=0`
+
+  Defining this macro to 1 before including the jitify header causes
+  demangling to be done using the cuFilt library instead of jitify's
+  built-in demangler implementation. This requires at least CUDA
+  version 11.4, and the application must be linked with the
+  libcufilt.a static library.
+
 <a name="compiler_options"/>
 
 ## Compiler options
 
 The Jitify API accepts options that can be used to control compilation
 and linking. While most options are simply passed through to NVRTC
-(for compiler options) or the CUDA cuLink APIs (for linker options),
-some trigger special behavior in Jitify as detailed below:
+(for compiler options) or the CUDA cuLink or nvJitLink APIs (for linker
+options), some trigger special behavior in Jitify as detailed below:
 
 - `-I<dir>`
 
@@ -381,3 +401,63 @@ Linker options:
   `-l<library>`, the unmodified `<library>` name is tried first,
   before searching for the file in the `-L` directories in the order
   they are listed.
+
+- `--use-culink (-use-culink)`
+
+  Forces linking to be done using the CUDA driver's `cuLink` APIs
+  instead of the `nvJitLink` library. Has no effect before CUDA 12.0.
+  Note that the `cuLink` APIs do not support LTO in CUDA 12+.
+
+The following linker options are mapped directly to options in the
+`cuLink`/`nvJitLink` APIs, but do not necessarily match exactly the
+option names used by those APIs. They provide a consistent interface
+(matching nvcc/nvrtc where possible) regardless of the underlying
+implementation.
+
+- `--device-debug (-G)`
+
+  Enables the generation of debug information.
+
+- `--generate-line-info (NOT -lineinfo)`
+
+  Enables the generation of source line information.
+  Note that the short form `-lineinfo` is not supported due to
+  ambiguity with the `-l` option.
+
+- `--gpu-name=sm_XX (-arch)`
+
+  Specifies the GPU architecture (e.g., "sm_80"). Note that this is a
+  required option when using `nvJitLink` (the default in CUDA 12+).
+
+- `--maxrregcount=N (-maxrregcount)`
+
+  Specifies the maximum number of registers to use.
+
+- `--opt-level=N (-O)`
+
+  Specifies the optimization level.
+
+- `--verbose (-v)`
+
+  Enables verbose logging.
+
+- `--ftz=true/false (-ftz) [default=false]`
+
+  Specifies flush-to-zero for denormal floating point values.
+
+- `--prec-div=true/false (-prec-div) [default=true]`
+
+  Specifies full-precision floating point division.
+
+- `--prec-sqrt=true/false (-prec-sqrt) [default=true]`
+
+  Specifies full-precision floating point square root.
+
+- `--fmad=true/false (-fmad) [default=true]`
+
+  Specifies the use of fused multiply-add operations.
+
+- `--use_fast_math (-use_fast_math)`
+
+  Enables the use of fast math operations. Equivalent to `--ftz=true
+  --prec-div=false --prec-sqrt=false --fmad=true`.


### PR DESCRIPTION
Adds support for the [nvJitLink](https://developer.nvidia.com/blog/cuda-12-0-compiler-support-for-runtime-lto-using-nvjitlink-library/) library, which is used instead of the cuLink APIs as of CUDA 12.0.

This re-enables support for LTO in CUDA 12+.

This change is intended to be transparent to end users. It can be force-disabled by passing the linker flag "--use-culink".

Also fixes a few bugs in the linker flag handling, and updates the user guide. See commit messages for details.