### PR TITLE
WAR for __has_include

### DIFF
--- a/jitify_test.cu
+++ b/jitify_test.cu
@@ -961,8 +961,6 @@ static const char* const builtin_numeric_cuda_std_limits_program_source =
     "builtin_numeric_cuda_std_limits_program\n"
     "#include <climits>\n"
     "#include <limits>\n"
-    "#include <cuda/std/climits>\n" // test fails without this explicit include
-    "#include <cuda/std/limits>\n"
     "struct MyType {};\n"
     "namespace cuda {\n"
     "namespace std {\n"


### PR DESCRIPTION
This WAR addresses an issue where nvrtc can fail to correctly deal with statements of the form
```c++
#if __has_include(<HEADER_NAME>)
```
where even if we have the header present in the set of includes it fails to return true.  The WAR here is to search for such statements when we load up headers, and if the header in question in manually found, we replace the statement with 
```c++
#if 1
```
and if not, replace it with
```c++
#if 0
```

With this WAR in place, we no longer need the unneeded includes in the `builtin_numeric_cuda_std_limits_program` program code, since these will be automatically included now as per @robertmaynard's original intention.