### PR TITLE
Extend portability

### DIFF
--- a/jitify2.hpp
+++ b/jitify2.hpp
@@ -5771,7 +5771,7 @@ inline std::string remove_cpp_comments_and_line_continuations(
       // Elide comments and line continuations.
     }
   }
-  result.append(source, old_pos);
+  result.append(source.substr(old_pos));
   return result;
 }
 
@@ -5838,7 +5838,7 @@ inline std::string remove_cpp_whitespace(const std::string& source) {
       }
     }
   }
-  result.append(source, old_pos);
+  result.append(source.substr(old_pos));
   return result;
 }
 
@@ -6341,7 +6341,13 @@ class NewFile {
     fl.l_whence = SEEK_SET;  // Start at beginning of file
     // Note: The Open File Descriptor (OFD) version of this call ensures that
     // the lock is per-descriptor not per-process (and so is thread-safe).
+    
+#ifdef _POSIX_VERSION
+    bool success = ::fcntl(fd_, F_SETLKW, &fl) == 0;
+#else
     bool success = ::fcntl(fd_, F_OFD_SETLKW, &fl) == 0;
+#endif
+
 #endif
     error_ = get_error_msg(success, "lock");
     return success;

--- a/jitify2.hpp
+++ b/jitify2.hpp
@@ -6341,13 +6341,7 @@ class NewFile {
     fl.l_whence = SEEK_SET;  // Start at beginning of file
     // Note: The Open File Descriptor (OFD) version of this call ensures that
     // the lock is per-descriptor not per-process (and so is thread-safe).
-    
-#ifdef _POSIX_VERSION
-    bool success = ::fcntl(fd_, F_SETLKW, &fl) == 0;
-#else
     bool success = ::fcntl(fd_, F_OFD_SETLKW, &fl) == 0;
-#endif
-
 #endif
     error_ = get_error_msg(success, "lock");
     return success;

--- a/jitify2.hpp
+++ b/jitify2.hpp
@@ -5771,7 +5771,7 @@ inline std::string remove_cpp_comments_and_line_continuations(
       // Elide comments and line continuations.
     }
   }
-  result.append(source.substr(old_pos));
+  result.append(source, old_pos, std::string::npos);
   return result;
 }
 
@@ -5838,7 +5838,7 @@ inline std::string remove_cpp_whitespace(const std::string& source) {
       }
     }
   }
-  result.append(source.substr(old_pos));
+  result.append(source, old_pos, std::string::npos);
   return result;
 }
 


### PR DESCRIPTION
- gcc 6.3 seems doesn't support usage of  `std::basic_string<char>::append(const string&, size_t&)`
- `F_SETLKW` for POSIX, `F_OFD_SETLKW` for non-POSIX, according to https://man7.org/linux/man-pages/man2/fcntl.2.html