### PR TITLE
LONG_MAX fix

### DIFF
--- a/jitify.hpp
+++ b/jitify.hpp
@@ -1469,7 +1469,7 @@ static const char* jitsafe_header_limits_h = R"(
  #if __WORDSIZE == 64
   # define LONG_MAX  LLONG_MAX
  #else
-  # define LONG_MAX  UINT_MAX
+  # define LONG_MAX  INT_MAX
  #endif
  #define LONG_MIN    (-LONG_MAX - 1)
  #if __WORDSIZE == 64


### PR DESCRIPTION
LONG_MAX is not unsigned 4294967295 , this has been giving me a narrowing conversion error when trying to use the cub block_reduce header.