### PR TITLE
Use the loaded headers from the previous file

### DIFF
--- a/jitify2_preprocess.cpp
+++ b/jitify2_preprocess.cpp
@@ -250,7 +250,7 @@ int main(int argc, char* argv[]) {
     }
 
     PreprocessedProgram preprocessed =
-        Program(source_filename, source)->preprocess(options);
+        Program(source_filename, source, all_header_sources)->preprocess(options);
     if (!preprocessed) {
       std::cerr << "Error processing source file " << source_filename << "\n"
                 << preprocessed.error() << std::endl;

--- a/jitify2_preprocess.cpp
+++ b/jitify2_preprocess.cpp
@@ -250,7 +250,9 @@ int main(int argc, char* argv[]) {
     }
 
     PreprocessedProgram preprocessed =
-        Program(source_filename, source, all_header_sources)->preprocess(options);
+        Program(source_filename, source,
+                share_headers ? all_header_sources : StringMap{})
+                ->preprocess(options);
     if (!preprocessed) {
       std::cerr << "Error processing source file " << source_filename << "\n"
                 << preprocessed.error() << std::endl;


### PR DESCRIPTION
Instead of preprocessing every source file from scratch, why not use the already loaded headers?

Please correct me if I'm wrong.

Currently, `jitify` loads and preprocesses the source files in a distributed approach, i.e. each file is preprocessed independently from the others, and the loaded headers are then added to the `all_header_sources` map. `std::unordered_map::insert()` will automatically filter redundant entries on a first-in first-out basis.

This is all fine, but since the files are preprocessed one after the other, why not instead add the already known headers from the previous files to the list of headers that `nvrtc` can use for the next file? As I'm sure you've noticed, letting `jitify` collecting the headers from `nvrtc`'s error messages quickly adds up when there's a lot of headers. For files that include a lot of the same headers (which I assume is a very common scenario), this simple change makes a big difference performance-wise and should produce exactly the same output, right? I use `--shared-headers` option and it seems to work fine.

HTH,
Thomas
