### PR TITLE
Address jitify2 warnings under Visual Studio 2022

### DIFF
--- a/jitify2.hpp
+++ b/jitify2.hpp
@@ -2091,7 +2091,7 @@ inline bool endswith(StringRef str, StringRef suffix) {
 
 inline bool is_true_value(std::string str) {
   std::transform(str.begin(), str.end(), str.begin(),
-                 [](unsigned char c) { return std::tolower(c); });
+                 [](unsigned char c) { return static_cast<unsigned char>(std::tolower(c)); });
   return !(str == "false" || str == "off" || str == "no" || str == "0");
 }
 
@@ -2954,7 +2954,7 @@ inline int parse_arch_flag(const StringVec& options, bool* is_virtual,
 // capability such as 61 for sm_61.
 inline int get_current_device_compute_capability(std::string* error = nullptr) {
   CUdevice device;
-  int cc_major, cc_minor;
+  int cc_major = 0, cc_minor = 0;
   CUresult ret;
   if (!cuda()) {
     if (error) *error = cuda().error();


### PR DESCRIPTION
The 3 warnings addressed are shown below.

```
1>C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.36.32532\include\algorithm(3456): warning C4244: '=': conversion from 'int' to 'char', possible loss of data
1>C:\Users\Robert\fgpu2\fgpu2\build\_deps\jitify-src\jitify/jitify2.hpp(2093): note: see reference to function template instantiation '_OutIt std::transform<std::_String_iterator<std::_String_val<std::_Simple_types<_Elem>>>,std::_String_iterator<std::_String_val<std::_Simple_types<_Elem>>>,jitify2::detail::is_true_value::<lambda_1c4b3a884b5a8315db7fcb8afefb2bc5>>(const _InIt,const _InIt,_OutIt,_Fn)' being compiled
1>        with
1>        [
1>            _OutIt=std::_String_iterator<std::_String_val<std::_Simple_types<char>>>,
1>            _Elem=char,
1>            _InIt=std::_String_iterator<std::_String_val<std::_Simple_types<char>>>,
1>            _Fn=jitify2::detail::is_true_value::<lambda_1c4b3a884b5a8315db7fcb8afefb2bc5>
1>        ]
1>C:\Users\Robert\fgpu2\fgpu2\build\_deps\jitify-src\jitify\jitify2.hpp(2973): warning C4701: potentially uninitialized local variable 'cc_major' used
1>C:\Users\Robert\fgpu2\fgpu2\build\_deps\jitify-src\jitify\jitify2.hpp(2973): warning C4701: potentially uninitialized local variable 'cc_minor' used
```

--------------------------------


*Haven't managed to resolve all issues on our CI yet, so may have further changes.*

[CUDA 11.0 x Visual Studio 2019](https://github.com/FLAMEGPU/FLAMEGPU2/actions/runs/6904121953/job/18784167083?pr=1150#step:9:736) is unhappy with something related to the implementation of `SafeFunction`, but its a nasty template err related to `std::function`.

```
     1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.29.30133\include\functional(822): error #304: no instance of function template "std::_Invoker_ret<_Rx, false>::_Call [with _Rx=CUresult]" matches the argument list [D:\a\FLAMEGPU2\FLAMEGPU2\build\FLAMEGPU\flamegpu.vcxproj]
                     argument types are: (std::decay_t<std::remove_reference_t<jitify2::detail::function_type<CUresult, int *> *&>>, int *)
                   detected during:
                     instantiation of "_Rx std::_Func_impl_no_alloc<_Callable, _Rx, _Types...>::_Do_call(_Types &&...) [with _Callable=std::decay_t<std::remove_reference_t<jitify2::detail::function_type<CUresult, int *> *&>>, _Rx=CUresult, _Types=<int *>]" 
         (798): here
                     instantiation of "std::_Func_impl_no_alloc<_Callable, _Rx, _Types...>::_Func_impl_no_alloc(_Other &&) [with _Callable=std::decay_t<std::remove_reference_t<jitify2::detail::function_type<CUresult, int *> *&>>, _Rx=CUresult, _Types=<int *>, _Other=std::remove_reference_t<jitify2::detail::function_type<CUresult, int *> *&>, <unnamed>=0]" 
         (916): here
                     instantiation of "void std::_Func_class<_Ret, _Types...>::_Reset(_Fx &&) [with _Ret=CUresult, _Types=<int *>, _Fx=std::remove_reference_t<jitify2::detail::function_type<CUresult, int *> *&>]" 
         (1042): here
                     instantiation of "std::function<_Fty>::function(_Fx) [with _Fty=CUresult (int *), _Fx=jitify2::detail::function_type<CUresult, int *> *, <unnamed>=int]" 
         D:\a\FLAMEGPU2\FLAMEGPU2\build\_deps\jitify-src\jitify/jitify2.hpp(1194): here
                     instantiation of "jitify2::detail::SafeFunction<ResultType, Args...> jitify2::detail::DynamicLibrary::function<ResultType,Args...>(const char *) const [with ResultType=CUresult, Args=<int *>]" 
         D:\a\FLAMEGPU2\FLAMEGPU2\build\_deps\jitify-src\jitify/jitify2.hpp(1240): here
```

<details>
<summary>(Resolved)</summary>

[manylinux2014](https://github.com/FLAMEGPU/FLAMEGPU2/actions/runs/6904121962/job/18784164920?pr=1150#step:11:353) is unhappy with the use of `F_OFD_SETLKW`.

```
Error: /__w/FLAMEGPU2/FLAMEGPU2/build/_deps/jitify-src/jitify/jitify2.hpp(6344): error: identifier "F_OFD_SETLKW" is undefined
```
In both of these cases, I'm assuming compiler/stdlib age is the issue. I'm told we still **require** support for manylinux2014 as several HPC systems are still running centos7, however we may be able to address that issue by switching to the less safe `F_OFD` flag under centos7.
</details>
