### PR TITLE
Fixed compile error and switch case warning

### DIFF
--- a/jitify2.hpp
+++ b/jitify2.hpp
@@ -1680,9 +1680,9 @@ class LibNvJitLink
 #if CUDA_VERSION >= 12030
     case NVJITLINK_ERROR_THREADPOOL: return "NVJITLINK_ERROR_THREADPOOL";
 #endif
-    default: return "(unknown nvJitLink error)";
     }
     // clang-format on
+    return "(unknown nvJitLink error)";
   }
 
   nvJitLinkInputType get_input_type(CUjitInputType cuda_input_type) const {

--- a/jitify2.hpp
+++ b/jitify2.hpp
@@ -1680,9 +1680,9 @@ class LibNvJitLink
 #if CUDA_VERSION >= 12030
     case NVJITLINK_ERROR_THREADPOOL: return "NVJITLINK_ERROR_THREADPOOL";
 #endif
+    default: return "(unknown nvJitLink error)";
     }
     // clang-format on
-    return "(unknown nvJitLink error)";
   }
 
   nvJitLinkInputType get_input_type(CUjitInputType cuda_input_type) const {
@@ -3717,8 +3717,9 @@ inline void copy_compiler_flag_for_linker_ptxas(
   for (int idx : idxs) {
     const Option& compiler_option = compiler_options[idx];
     const Option linker_option =
-        output_key.empty() ? compiler_option
-                           : Option(output_key, compiler_option.value());
+        output_key.empty()
+            ? compiler_option
+            : Option(std::string{output_key}, compiler_option.value());
     linker_options->push_back(linker_option);
   }
 }


### PR DESCRIPTION
This merge requests fixes the compile error in CUDA 12.* where the Option's `std::string` constructor is called with a `StringRef` (`std::string_view`) which is not a valid implicit conversion.

GCC also is not convinced that all branches in jitify2.hpp:1682 are taken, and thus raises a warning, we have warnings as errors in CUDF so it breaks our build.