### PR TITLE
Add new features to jitify2

### DIFF
--- a/jitify2_test.cu
+++ b/jitify2_test.cu
@@ -3041,10 +3041,19 @@ int main(int argc, char** argv) {
   // destroyed").
   cudaFree(0);
   ::testing::InitGoogleTest(&argc, argv);
-  // Test order is actually undefined, so we use filters to force the
-  // AssertHeader test to run last.
-  ::testing::GTEST_FLAG(filter) += ":-Jitify2Test.AssertHeader";
-  int result = RUN_ALL_TESTS();
-  ::testing::GTEST_FLAG(filter) = "Jitify2Test.AssertHeader";
-  return result | RUN_ALL_TESTS();
+  int result;
+  // Note: Googletest doesn't expose any way to check if the filter matches a
+  // test, so this is just an approximation for whether the AssertHeader
+  // test is being run with other tests.
+  if (::testing::GTEST_FLAG(filter).find("*") != std::string::npos) {
+    // Test order is actually undefined, so we use filters to force the
+    // AssertHeader test to run last.
+    ::testing::GTEST_FLAG(filter) += ":-Jitify2Test.AssertHeader";
+    result = RUN_ALL_TESTS();
+    ::testing::GTEST_FLAG(filter) = "Jitify2Test.AssertHeader";
+    result |= RUN_ALL_TESTS();
+  } else {
+    result = RUN_ALL_TESTS();
+  }
+  return result;
 }

--- a/jitify2_test.cu
+++ b/jitify2_test.cu
@@ -157,6 +157,13 @@ __global__ void my_kernel(T* data) {
   CHECK_CUDART(cudaFree(d_data));
 }
 
+TEST(Jitify2Test, GetDirectoryHelpers) {
+  EXPECT_NE(get_user_cache_dir(), "");
+  EXPECT_TRUE(
+      jitify2::detail::endswith(get_user_cache_dir("my_cache"), "my_cache"));
+  EXPECT_NE(get_cuda_include_dir(), "");
+}
+
 TEST(Jitify2Test, ReadmeExampleCode) {
   std::string program_source = R"(
 #include <cmath>

--- a/jitify2_test.cu
+++ b/jitify2_test.cu
@@ -483,8 +483,9 @@ __global__ void my_kernel(const T*, U*) {}
   for (int i = 0; i < nrep; ++i) {
     // Benchmark direct kernel launch.
     auto t0 = std::chrono::steady_clock::now();
-    cuda().LaunchKernel()(kernel->function(), grid.x, grid.y, grid.z, block.x,
-                          block.y, block.z, 0, 0, arg_ptrs, nullptr);
+    cuda().LaunchKernel()((CUfunction)kernel->function(), grid.x, grid.y,
+                          grid.z, block.x, block.y, block.z, 0, 0, arg_ptrs,
+                          nullptr);
     auto dt = std::chrono::steady_clock::now() - t0;
     // Using the minimum is more robust than the average (though this test still
     // remains sensitive to the system environment and has been observed to fail
@@ -579,13 +580,13 @@ __global__ void my_kernel(const T* __restrict__ idata, T* __restrict__ odata) {}
   JITIFY_TEST_CHECK_HITS(0, 2, 0, 2);
   kernel = cache.get_kernel(/* key = */ 2, my_kernel.instantiate<int>());
   ASSERT_EQ(get_error(kernel), "");
-  CUfunction function_int = kernel->function();
+  CudaFunction function_int = kernel->function();
   JITIFY_TEST_CHECK_HITS(0, 3, 0, 3);
   cache.reset_stats();
   JITIFY_TEST_CHECK_HITS(0, 0, 0, 0);
   kernel = cache.get_kernel(/* key = */ 0, my_kernel.instantiate<float>());
   ASSERT_EQ(get_error(kernel), "");
-  CUfunction function_float = kernel->function();
+  CudaFunction function_float = kernel->function();
   JITIFY_TEST_CHECK_HITS(0, 1, 1, 0);
   kernel = cache.get_kernel(/* key = */ 2, my_kernel.instantiate<int>());
   ASSERT_EQ(get_error(kernel), "");
@@ -658,13 +659,13 @@ __global__ void my_kernel(const T* __restrict__ idata, T* __restrict__ odata) {}
   JITIFY_TEST_CHECK_HITS(0, 2, 0, 2);
   kernel = cache.get_kernel(my_kernel.instantiate<int>());
   ASSERT_EQ(get_error(kernel), "");
-  CUfunction function_int = kernel->function();
+  CudaFunction function_int = kernel->function();
   JITIFY_TEST_CHECK_HITS(0, 3, 0, 3);
   cache.reset_stats();
   JITIFY_TEST_CHECK_HITS(0, 0, 0, 0);
   kernel = cache.get_kernel(my_kernel.instantiate<float>());
   ASSERT_EQ(get_error(kernel), "");
-  CUfunction function_float = kernel->function();
+  CudaFunction function_float = kernel->function();
   JITIFY_TEST_CHECK_HITS(0, 1, 1, 0);
   kernel = cache.get_kernel(my_kernel.instantiate<int>());
   ASSERT_EQ(get_error(kernel), "");

--- a/jitify2_user_guide.md
+++ b/jitify2_user_guide.md
@@ -302,6 +302,13 @@ documentation for many jitify features.
   disables the static assertion that kernel launch arguments are
   trivially copyable.
 
+- `JITIFY_ENABLE_NVCC=0`
+
+  Defining this macro to 1 before including the jitify header
+  enables support for runtime compilation using nvcc instead of NVRTC
+  via the "--nvcc" compiler option. See the documentation for "--nvcc"
+  in this guide for more information.
+
 <a name="compiler_options"/>
 
 ## Compiler options
@@ -416,6 +423,36 @@ options), some trigger special behavior in Jitify as detailed below:
   implementations. This is experimental because it does not currently
   support the transformation of `namespace std {` (as is used for
   specializations of standard library templates).
+
+- `--nvcc (-nvcc)`
+
+  [SOMEWHAT EXPERIMENTAL]
+
+  Requires JITIFY_ENABLE_NVCC=1 to be defined before including the
+  jitify header.
+
+  This option causes runtime compilation to use nvcc instead of NVRTC.
+  Nvcc is not used for prepocessing, but the "--nvcc" option can be
+  specified during preprocessing and it will be kept for compilation.
+
+  Use of nvcc is somewhat experimental and intended only for cases
+  where NVRTC-specific issues need to be worked around. Some NVRTC
+  features are not supported by nvcc (e.g., "-default-device"). Using
+  nvcc also means that, during compilation, source files must be
+  temporarily written to the filesystem, the nvcc executable must be
+  located, and nvcc must be invoked as a subprocess (this is all
+  fully automated). It also requires that standard library and
+  CUDA Toolkit headers are available to nvcc at runtime in the
+  filesystem. (Unlike with NVRTC, nvcc and certain required CUDA
+  Toolkit headers cannot be redistributed).
+
+  By default, the nvcc executable is found using a heuristic, but
+  this can be overridden by setting the JITIFY_NVCC environment
+  variable or specifying the option "--nvcc-path=/path/to/nvcc".
+
+- `--nvcc-path=/path/to/nvcc (-nvcc-path)`
+
+  Specifies the path at which to find the nvcc executable.
 
 Linker options:
 

--- a/jitify2_user_guide.md
+++ b/jitify2_user_guide.md
@@ -309,6 +309,14 @@ documentation for many jitify features.
   via the "--nvcc" compiler option. See the documentation for "--nvcc"
   in this guide for more information.
 
+- `JITIFY_USE_CONTEXT_INDEPENDENT_LOADING=1`
+
+  Defining this macro to 0 before including the jitify header
+  disables use of the cuLibrary* and cuKernel* APIs (alternatives to
+  the cuModule* and cuFunction* APIs since CUDA 12.0). If disabled
+  (or unavailable due to old CUDA version), modules must be loaded
+  and managed separately on each device/context.
+
 <a name="compiler_options"/>
 
 ## Compiler options

--- a/jitify2_user_guide.md
+++ b/jitify2_user_guide.md
@@ -421,6 +421,24 @@ options), some trigger special behavior in Jitify as detailed below:
   disables the use of builtin workarounds for certain libraries
   (e.g., Thrust and CUB).
 
+- `--pch (-pch)`
+
+  This option is passed through to NVRTC to enable pre-compiled
+  headers (PCH), which can significantly speed up compilation of some
+  programs (see NVRTC documentation for full details). Other NVRTC
+  PCH options can also be used.
+
+  If this option is present without a corresponding `--pch-dir`
+  option, a `--pch-dir` will automatically be specified using
+  a unique temporary directory.
+
+  One caveat with enabling PCH in Jitify is that PCH does not
+  support `#line` directives, which Jitify normally adds during
+  preprocessing. To avoid this issue, when PCH is enabled Jitify
+  will automatically remove these `#line` directives prior to
+  compilation, which may cause slightly incorrect line numbers in
+  error messages.
+
 - `--cuda-std (-cuda-std)`
 
   [EXPERIMENTAL]

--- a/jitify2_user_guide.md
+++ b/jitify2_user_guide.md
@@ -439,6 +439,34 @@ options), some trigger special behavior in Jitify as detailed below:
   compilation, which may cause slightly incorrect line numbers in
   error messages.
 
+  Note that PCH is not used during preprocessing, but the flags can
+  be specified during preprocessing and they will be kept for
+  compilation.
+
+- `--no-pch-auto-resize (-no-pch-auto-resize)`
+
+  This option disables auto-resizing of the process-wide NVRTC PCH
+  heap. By default, when PCH generation fails due to heap exhaustion,
+  Jitify automatically resizes it based on the size required for the
+  compilation.
+
+  When PCH generation fails, the compilation log will contain a
+  warning similar to the following:
+  "warning #639-D: insufficient preallocated memory for generation
+  of precompiled header file".
+  When applicable, Jitify will add a message to the log similar to:
+  "Automatically resizing PCH heap".
+  When this happens, the compilation is not automatically re-tried,
+  so PCH generation will occur during the _next_ compilation of the
+  program.
+
+  To avoid the PCH heap being resized on the fly, users can
+  pre-resize it using:
+  `jitify2::nvrtc().SetPCHHeapSize()(desired_size_in_bytes);`
+  The default heap size can also be set via the `NVRTC_PCH_HEAP_SIZE=`
+  environment variable.
+  See the NVRTC documentation for more details about the PCH heap.
+
 - `--cuda-std (-cuda-std)`
 
   [EXPERIMENTAL]

--- a/jitify2_user_guide.md
+++ b/jitify2_user_guide.md
@@ -18,6 +18,8 @@ Jitify User Guide
 
 [Compiler options](#compiler_options)
 
+[Environment variables](#environment_variables)
+
 <a name="basic_usage"/>
 
 ## Basic usage
@@ -594,3 +596,17 @@ implementation.
 
   Enables the use of fast math operations. Equivalent to `--ftz=true
   --prec-div=false --prec-sqrt=false --fmad=true`.
+
+<a name="environment_variables"/>
+
+## Environment variables
+
+- `JITIFY_CUDA_HOME`
+
+  Specifies the path to the CUDA Toolkit root directory. This takes
+  priority over the `CUDA_HOME` environment variable.
+
+- `JITIFY_NVCC`
+
+  Specifies the path to the `nvcc` executable. This is only used if the
+  `--nvcc-path=<path>` compiler option is not present.

--- a/jitify2_user_guide.md
+++ b/jitify2_user_guide.md
@@ -196,8 +196,10 @@ disk:
 #include "myprog2.cu.jit.hpp"
 ...
   using jitify2::ProgramCache;
+  using jitify2::get_user_cache_dir;
   static ProgramCache<> myprog1_cache(
-      /*max_size=*/100, *myprog1_cu_jit, myheaders_jit, "/tmp/my_jit_cache");
+      /*max_size=*/100, *myprog1_cu_jit, myheaders_jit,
+      get_user_cache_dir("my_jit_cache"));
 ```
 
 For advanced use-cases, multiple kernels can be instantiated in a single program:
@@ -220,9 +222,11 @@ For improved performance, the cache can be given user-defined keys:
 ```c++
   using jitify2::ProgramCache;
   using jitify2::Kernel;
+  using jitify2::get_user_cache_dir;
   using MyKeyType = uint32_t;
   static ProgramCache<MyKeyType> myprog1_cache(
-      /*max_size=*/100, *myprog1_cu_jit, myheaders_jit, "/tmp/my_jit_cache");
+      /*max_size=*/100, *myprog1_cu_jit, myheaders_jit,
+      get_user_cache_dir("my_jit_cache"));
   std::string kernel1 = Template("my_kernel1").instantiate(123, Type<float>());
   Kernel kernel = myprog1_cache.get_kernel(MyKeyType(7), kernel1);
 ```


### PR DESCRIPTION
Adds support for:

- Reflecting enum values.
- Kernel launch attributes.
- Compilation cancellation.
- nvcc as an alternative to nvrtc.
- Context-independent module loading.
- Pre-compiled headers.

See commit messages for full details.

Also updates the README for jitify2.