### PR TITLE
[BUG] Fix bug in extracting include paths

### DIFF
--- a/jitify2.hpp
+++ b/jitify2.hpp
@@ -8952,7 +8952,9 @@ inline PreprocessedProgram PreprocessedProgram::preprocess(
     include_path = detail::get_real_path(include_path.c_str());
   }
   // Remove empty (non-existent) include paths.
-  std::remove(include_paths.begin(), include_paths.end(), std::string{});
+  auto new_include_paths_end =
+      std::remove(include_paths.begin(), include_paths.end(), std::string{});
+  include_paths.erase(new_include_paths_end, include_paths.end());
   // Returns index of longest matching include dir, or -1 if no match.
   auto match_include_path = [&](std::string path, size_t* length) -> int {
     *length = 0;


### PR DESCRIPTION
This pull request fixes a bug in extracting include paths. It calls std::remove on the include paths, without erasing the elements. `std::remove` shifts the elements to the end of the vector.
This also caused a CI failure for CUDF as it emits a warning (we treat all warnings as errors).