### PR TITLE
Update nvrtc_cli for CUDA13 LTOIR API

### DIFF
--- a/nvrtc_cli.cpp
+++ b/nvrtc_cli.cpp
@@ -171,7 +171,14 @@ nvrtcResult compile_program(
   }
 #endif
 
-#if CUDART_VERSION >= 11040
+#if CUDART_VERSION >= 13000
+  size_t nvvm_size;
+  CHECK_NVRTC(nvrtcGetLTOIRSize(nvrtc_program, &nvvm_size));
+  if (nvvm_size) {
+    compiled->nvvm.resize(nvvm_size);
+    CHECK_NVRTC(nvrtcGetLTOIR(nvrtc_program, compiled->nvvm.data()));
+  }  
+#elif CUDART_VERSION >= 11040
   size_t nvvm_size;
   CHECK_NVRTC(nvrtcGetNVVMSize(nvrtc_program, &nvvm_size));
   if (nvvm_size) {


### PR DESCRIPTION
CUDA 13 changed the NVVM API to LTOIR. This commit updates the names conditionally for CUDA 13.