### PR TITLE
Add simple fix for MSVC name mangling

### DIFF
--- a/jitify.hpp
+++ b/jitify.hpp
@@ -852,8 +852,12 @@ struct type_reflection {
     // WAR for typeid discarding cv qualifiers on value-types
     // Wrap type in dummy template class to preserve cv-qualifiers, then strip
     // off the wrapper from the resulting string.
-    std::string wrapped_name =
+  #ifdef _MSC_VER
+      std::string wrapped_name = typeid(JitifyTypeNameWrapper_<T>).name();
+  #else
+      std::string wrapped_name =
         demangle_native_type(typeid(JitifyTypeNameWrapper_<T>));
+  #endif
     // Note: The reflected name of this class also has namespace prefixes.
     const std::string wrapper_class_name = "JitifyTypeNameWrapper_<";
     size_t start = wrapped_name.find(wrapper_class_name);


### PR DESCRIPTION
I don't know if I am the only person who encounters this, but when I use Jitify in my project (https://github.com/projectchrono/DEM-Engine), on Windows with MSVC, the jit-ed kernel name mangling was never right, until I added this basically one-line fix. I hope my fix can be incorporated, but if the problem was due to the fact that I incorrectly used Jitify on Windows, kindly let me know, too.

Platform compatibility improvement:

* Modified the `type_reflection` struct in `jitify.hpp` to use `typeid(...).name()` directly on MSVC, while retaining the use of `demangle_native_type` for other platforms. This addresses differences in how type names are handled between compilers.